### PR TITLE
Refactor: Connection param object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode
 
 # Compiled binary
 /dist

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ fmt:
 run:
 	go run ./
 
+## Run the application in debug mode
+debug-server:
+	go build -gcflags="all=-N -l" -o bin/$(APP_NAME)-debug ./
+	-dlv exec ./bin/$(APP_NAME)-debug --headless --listen=127.0.0.1:38697 --api-version=2
+	@printf "\033[?1049l\033[?25h"
+	@stty sane
+	@reset
+
 ## Build for multiple platforms
 build-all:
 	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o bin/$(APP_NAME)-darwin-amd64 ./

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,10 @@ run:
 
 ## Run the application in debug mode
 debug-server:
-	go build -gcflags="all=-N -l" -o bin/$(APP_NAME)-debug ./
-	-dlv exec ./bin/$(APP_NAME)-debug --headless --listen=127.0.0.1:38697 --api-version=2
+	@mkdir -p tmp || true
+	@-pkill -f "dlv.*38697" || true
+	go build -gcflags="all=-N -l" -o tmp/$(APP_NAME)-debug ./
+	go run github.com/go-delve/delve/cmd/dlv@latest exec ./tmp/$(APP_NAME)-debug --headless --listen=127.0.0.1:38697 --api-version=2
 	@printf "\033[?1049l\033[?25h"
 	@stty sane
 	@reset
@@ -75,6 +77,7 @@ snapshot:
 ## Install development dependencies
 dev-deps:
 	go install github.com/goreleaser/goreleaser/v2@v2.13.1
+	go install github.com/go-delve/delve/cmd/dlv@latest
 
 ## --- Docker Examples ---
 

--- a/internal/cmd/commands_config_test.go
+++ b/internal/cmd/commands_config_test.go
@@ -31,7 +31,7 @@ func TestLoadFavorites(t *testing.T) {
 func TestAddFavorite(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cfg := testutil.NewTestConfig(t)
-		testutil.MustAddConnection(t, cfg, "test", "localhost", 6379, "", 0)
+		testutil.MustAddConnection(t, cfg, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0})
 		cmds := NewCommands(cfg, nil)
 		msg := cmds.AddFavorite(1, "mykey", "My Key")()
 		result := msg.(types.FavoriteAddedMsg)

--- a/internal/cmd/commands_config_test.go
+++ b/internal/cmd/commands_config_test.go
@@ -52,7 +52,7 @@ func TestAddFavorite(t *testing.T) {
 func TestRemoveFavorite(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cfg := testutil.NewTestConfig(t)
-		testutil.MustAddConnection(t, cfg, "test", "localhost", 6379, "", 0)
+		testutil.MustAddConnection(t, cfg, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0})
 		_, _ = cfg.AddFavorite(1, "mykey", "label")
 		cmds := NewCommands(cfg, nil)
 		msg := cmds.RemoveFavorite(1, "mykey")()

--- a/internal/cmd/commands_connection.go
+++ b/internal/cmd/commands_connection.go
@@ -58,13 +58,10 @@ func (c *Commands) DeleteConnection(id int64) tea.Cmd {
 	}
 }
 
-func (c *Commands) Connect(conn *types.Connection) tea.Cmd {
+func (c *Commands) Connect(conn types.Connection) tea.Cmd {
 	return func() tea.Msg {
 		if c.redis == nil {
 			return types.ConnectedMsg{Err: nil}
-		}
-		if conn == nil {
-			return types.ConnectedMsg{Err: fmt.Errorf("connection is nil")}
 		}
 		var err error
 		if conn.UseCluster {
@@ -88,13 +85,10 @@ func (c *Commands) Disconnect() tea.Cmd {
 	}
 }
 
-func (c *Commands) TestConnection(conn *types.Connection) tea.Cmd {
+func (c *Commands) TestConnection(conn types.Connection) tea.Cmd {
 	return func() tea.Msg {
 		if c.redis == nil {
 			return types.ConnectionTestMsg{Success: false, Err: nil}
-		}
-		if conn == nil {
-			return types.ConnectionTestMsg{Success: false, Err: fmt.Errorf("connection is nil")}
 		}
 
 		latency, err := c.redis.TestConnection(conn)

--- a/internal/cmd/commands_connection.go
+++ b/internal/cmd/commands_connection.go
@@ -22,12 +22,12 @@ func (c *Commands) LoadConnections() tea.Cmd {
 	}
 }
 
-func (c *Commands) AddConnection(name, host string, port int, password string, dbNum int, useCluster bool) tea.Cmd {
+func (c *Commands) AddConnection(conn types.Connection) tea.Cmd {
 	return func() tea.Msg {
 		if c.config == nil {
 			return types.ConnectionAddedMsg{Err: nil}
 		}
-		conn, err := c.config.AddConnection(name, host, port, password, dbNum, useCluster)
+		conn, err := c.config.AddConnection(conn)
 		if err != nil {
 			slog.Error("Failed to add connection", "error", err)
 		}
@@ -35,12 +35,12 @@ func (c *Commands) AddConnection(name, host string, port int, password string, d
 	}
 }
 
-func (c *Commands) UpdateConnection(id int64, name, host string, port int, password string, dbNum int, useCluster bool) tea.Cmd {
+func (c *Commands) UpdateConnection(conn types.Connection) tea.Cmd {
 	return func() tea.Msg {
 		if c.config == nil {
 			return types.ConnectionUpdatedMsg{Err: nil}
 		}
-		conn, err := c.config.UpdateConnection(id, name, host, port, password, dbNum, useCluster)
+		conn, err := c.config.UpdateConnection(conn)
 		if err != nil {
 			slog.Error("Failed to update connection", "error", err)
 		}
@@ -58,44 +58,16 @@ func (c *Commands) DeleteConnection(id int64) tea.Cmd {
 	}
 }
 
-func (c *Commands) Connect(host string, port int, password string, dbNum int, useCluster bool) tea.Cmd {
-	return func() tea.Msg {
-		if c.redis == nil {
-			return types.ConnectedMsg{Err: nil}
-		}
-		var err error
-		if useCluster {
-			err = c.redis.ConnectCluster([]string{fmt.Sprintf("%s:%d", host, port)}, password)
-		} else {
-			err = c.redis.Connect(host, port, password, dbNum)
-		}
-		if err != nil {
-			slog.Error("Failed to connect", "error", err)
-		}
-		return types.ConnectedMsg{Err: err}
-	}
-}
-
-func (c *Commands) AutoConnect(conn types.Connection) tea.Cmd {
+func (c *Commands) Connect(conn *types.Connection) tea.Cmd {
 	return func() tea.Msg {
 		if c.redis == nil {
 			return types.ConnectedMsg{Err: nil}
 		}
 		var err error
 		if conn.UseCluster {
-			err = c.redis.ConnectCluster([]string{fmt.Sprintf("%s:%d", conn.Host, conn.Port)}, conn.Password)
-		} else if conn.UseTLS {
-			if conn.TLSConfig == nil {
-				return types.ConnectedMsg{Err: fmt.Errorf("TLS requested but TLS configuration is missing")}
-			}
-			tlsCfg, tlsErr := conn.TLSConfig.BuildTLSConfig()
-			if tlsErr != nil {
-				slog.Error("Failed to build TLS config", "error", tlsErr)
-				return types.ConnectedMsg{Err: tlsErr}
-			}
-			err = c.redis.ConnectWithTLS(conn.Host, conn.Port, conn.Password, conn.DB, tlsCfg)
+			err = c.redis.ConnectCluster([]string{fmt.Sprintf("%s:%d", conn.Host, conn.Port)}, conn)
 		} else {
-			err = c.redis.Connect(conn.Host, conn.Port, conn.Password, conn.DB)
+			err = c.redis.Connect(conn)
 		}
 		if err != nil {
 			slog.Error("Failed to connect", "error", err)
@@ -113,12 +85,12 @@ func (c *Commands) Disconnect() tea.Cmd {
 	}
 }
 
-func (c *Commands) TestConnection(host string, port int, password string, db int) tea.Cmd {
+func (c *Commands) TestConnection(conn *types.Connection) tea.Cmd {
 	return func() tea.Msg {
 		if c.redis == nil {
 			return types.ConnectionTestMsg{Success: false, Err: nil}
 		}
-		latency, err := c.redis.TestConnection(host, port, password, db)
+		latency, err := c.redis.TestConnection(conn)
 		return types.ConnectionTestMsg{Success: err == nil, Latency: latency, Err: err}
 	}
 }

--- a/internal/cmd/commands_connection.go
+++ b/internal/cmd/commands_connection.go
@@ -63,6 +63,9 @@ func (c *Commands) Connect(conn *types.Connection) tea.Cmd {
 		if c.redis == nil {
 			return types.ConnectedMsg{Err: nil}
 		}
+		if conn == nil {
+			return types.ConnectedMsg{Err: fmt.Errorf("connection is nil")}
+		}
 		var err error
 		if conn.UseCluster {
 			err = c.redis.ConnectCluster([]string{fmt.Sprintf("%s:%d", conn.Host, conn.Port)}, conn)
@@ -90,6 +93,10 @@ func (c *Commands) TestConnection(conn *types.Connection) tea.Cmd {
 		if c.redis == nil {
 			return types.ConnectionTestMsg{Success: false, Err: nil}
 		}
+		if conn == nil {
+			return types.ConnectionTestMsg{Success: false, Err: fmt.Errorf("connection is nil")}
+		}
+
 		latency, err := c.redis.TestConnection(conn)
 		return types.ConnectionTestMsg{Success: err == nil, Latency: latency, Err: err}
 	}

--- a/internal/cmd/commands_connection_test.go
+++ b/internal/cmd/commands_connection_test.go
@@ -162,7 +162,7 @@ func TestDeleteConnection(t *testing.T) {
 func TestConnect(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, _ := newMockCmds()
-		msg := cmds.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
+		msg := cmds.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectedMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
@@ -172,7 +172,7 @@ func TestConnect(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		cmds, mock := newMockCmds()
 		mock.ConnectError = errors.New("connection refused")
-		msg := cmds.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
+		msg := cmds.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectedMsg)
 		if result.Err == nil {
 			t.Error("expected error")
@@ -181,7 +181,7 @@ func TestConnect(t *testing.T) {
 
 	t.Run("cluster mode", func(t *testing.T) {
 		cmds, _ := newMockCmds()
-		msg := cmds.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 7000, DB: 0, UseCluster: true})()
+		msg := cmds.Connect(types.Connection{Name: "test", Host: "localhost", Port: 7000, DB: 0, UseCluster: true})()
 		result := msg.(types.ConnectedMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
@@ -190,16 +190,7 @@ func TestConnect(t *testing.T) {
 
 	t.Run("nil redis", func(t *testing.T) {
 		cmds := NewCommands(nil, nil)
-		msg := cmds.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
-		result := msg.(types.ConnectedMsg)
-		if result.Err != nil {
-			t.Errorf("nil redis should not error: %v", result.Err)
-		}
-	})
-
-	t.Run("nil conn", func(t *testing.T) {
-		cmds := NewCommands(nil, nil)
-		msg := cmds.Connect(nil)()
+		msg := cmds.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectedMsg)
 		if result.Err != nil {
 			t.Errorf("nil redis should not error: %v", result.Err)
@@ -229,7 +220,7 @@ func TestTestConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
 		mock.TestConnectionLatency = 5 * time.Millisecond
-		msg := cmds.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
+		msg := cmds.TestConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionTestMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
@@ -245,7 +236,7 @@ func TestTestConnection(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		cmds, mock := newMockCmds()
 		mock.TestConnectionError = errors.New("connection failed")
-		msg := cmds.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
+		msg := cmds.TestConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionTestMsg)
 		if result.Err == nil {
 			t.Error("expected error")
@@ -257,16 +248,7 @@ func TestTestConnection(t *testing.T) {
 
 	t.Run("nil redis", func(t *testing.T) {
 		cmds := NewCommands(nil, nil)
-		msg := cmds.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
-		result := msg.(types.ConnectionTestMsg)
-		if result.Err != nil {
-			t.Errorf("nil redis should not error: %v", result.Err)
-		}
-	})
-
-	t.Run("nil conn", func(t *testing.T) {
-		cmds := NewCommands(nil, nil)
-		msg := cmds.TestConnection(nil)()
+		msg := cmds.TestConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionTestMsg)
 		if result.Err != nil {
 			t.Errorf("nil redis should not error: %v", result.Err)

--- a/internal/cmd/commands_connection_test.go
+++ b/internal/cmd/commands_connection_test.go
@@ -25,7 +25,7 @@ func TestConnectionErrorPaths(t *testing.T) {
 		mc := testutil.NewMockConfigClient()
 		mc.AddConnectionError = errors.New("add failed")
 		cmds := NewCommands(mc, nil)
-		msg := cmds.AddConnection("n", "h", 1, "", 0, false)()
+		msg := cmds.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionAddedMsg)
 		if result.Err == nil {
 			t.Error("expected error")
@@ -36,7 +36,7 @@ func TestConnectionErrorPaths(t *testing.T) {
 		mc := testutil.NewMockConfigClient()
 		mc.UpdateConnectionError = errors.New("update failed")
 		cmds := NewCommands(mc, nil)
-		msg := cmds.UpdateConnection(1, "n", "h", 1, "", 0, false)()
+		msg := cmds.UpdateConnection(types.Connection{ID: 1, Name: "n", Host: "h", Port: 1, Password: "p", DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionUpdatedMsg)
 		if result.Err == nil {
 			t.Error("expected error")

--- a/internal/cmd/commands_connection_test.go
+++ b/internal/cmd/commands_connection_test.go
@@ -63,7 +63,7 @@ func TestLoadConnections(t *testing.T) {
 
 	t.Run("success with connections", func(t *testing.T) {
 		cfg := testutil.NewTestConfig(t)
-		testutil.MustAddConnection(t, cfg, "test", "localhost", 6379, "", 0)
+		testutil.MustAddConnection(t, cfg, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0})
 		cmds := NewCommands(cfg, nil)
 		msg := cmds.LoadConnections()()
 		result := msg.(types.ConnectionsLoadedMsg)
@@ -89,7 +89,7 @@ func TestAddConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cfg := testutil.NewTestConfig(t)
 		cmds := NewCommands(cfg, nil)
-		msg := cmds.AddConnection("test", "localhost", 6379, "", 0, false)()
+		msg := cmds.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionAddedMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
@@ -101,7 +101,7 @@ func TestAddConnection(t *testing.T) {
 
 	t.Run("nil config", func(t *testing.T) {
 		cmds := NewCommands(nil, nil)
-		msg := cmds.AddConnection("test", "localhost", 6379, "", 0, false)()
+		msg := cmds.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionAddedMsg)
 		if result.Err != nil {
 			t.Errorf("nil config should not error: %v", result.Err)
@@ -112,9 +112,9 @@ func TestAddConnection(t *testing.T) {
 func TestUpdateConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cfg := testutil.NewTestConfig(t)
-		conn := testutil.MustAddConnection(t, cfg, "old", "localhost", 6379, "", 0)
+		conn := testutil.MustAddConnection(t, cfg, types.Connection{Name: "old", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		cmds := NewCommands(cfg, nil)
-		msg := cmds.UpdateConnection(conn.ID, "new", "localhost", 6380, "pass", 1, false)()
+		msg := cmds.UpdateConnection(types.Connection{ID: conn.ID, Name: "new", Host: "localhost", Port: 6380, Password: "pass", DB: 1, UseCluster: false})()
 		result := msg.(types.ConnectionUpdatedMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
@@ -126,7 +126,7 @@ func TestUpdateConnection(t *testing.T) {
 
 	t.Run("nil config", func(t *testing.T) {
 		cmds := NewCommands(nil, nil)
-		msg := cmds.UpdateConnection(1, "n", "h", 1, "p", 0, false)()
+		msg := cmds.UpdateConnection(types.Connection{ID: 1, Name: "n", Host: "h", Port: 1, Password: "p", DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionUpdatedMsg)
 		if result.Err != nil {
 			t.Errorf("nil config should not error: %v", result.Err)
@@ -137,7 +137,7 @@ func TestUpdateConnection(t *testing.T) {
 func TestDeleteConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cfg := testutil.NewTestConfig(t)
-		conn := testutil.MustAddConnection(t, cfg, "test", "localhost", 6379, "", 0)
+		conn := testutil.MustAddConnection(t, cfg, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		cmds := NewCommands(cfg, nil)
 		msg := cmds.DeleteConnection(conn.ID)()
 		result := msg.(types.ConnectionDeletedMsg)
@@ -162,7 +162,7 @@ func TestDeleteConnection(t *testing.T) {
 func TestConnect(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, _ := newMockCmds()
-		msg := cmds.Connect("localhost", 6379, "", 0, false)()
+		msg := cmds.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectedMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
@@ -172,7 +172,7 @@ func TestConnect(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		cmds, mock := newMockCmds()
 		mock.ConnectError = errors.New("connection refused")
-		msg := cmds.Connect("localhost", 6379, "", 0, false)()
+		msg := cmds.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectedMsg)
 		if result.Err == nil {
 			t.Error("expected error")
@@ -181,7 +181,7 @@ func TestConnect(t *testing.T) {
 
 	t.Run("cluster mode", func(t *testing.T) {
 		cmds, _ := newMockCmds()
-		msg := cmds.Connect("localhost", 7000, "", 0, true)()
+		msg := cmds.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 7000, DB: 0, UseCluster: true})()
 		result := msg.(types.ConnectedMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
@@ -190,162 +190,12 @@ func TestConnect(t *testing.T) {
 
 	t.Run("nil redis", func(t *testing.T) {
 		cmds := NewCommands(nil, nil)
-		msg := cmds.Connect("localhost", 6379, "", 0, false)()
+		msg := cmds.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectedMsg)
 		if result.Err != nil {
 			t.Errorf("nil redis should not error: %v", result.Err)
 		}
 	})
-}
-
-func TestAutoConnect(t *testing.T) {
-	t.Run("success standard", func(t *testing.T) {
-		cmds, mock := newMockCmds()
-		conn := types.Connection{Host: "localhost", Port: 6379, DB: 0}
-		msg := cmds.AutoConnect(conn)()
-		result := msg.(types.ConnectedMsg)
-		if result.Err != nil {
-			t.Errorf("unexpected error: %v", result.Err)
-		}
-		if len(mock.Calls) == 0 || mock.Calls[0] != "Connect" {
-			t.Errorf("expected Connect call, got %v", mock.Calls)
-		}
-	})
-
-	t.Run("success cluster", func(t *testing.T) {
-		cmds, mock := newMockCmds()
-		conn := types.Connection{Host: "localhost", Port: 7000, UseCluster: true}
-		msg := cmds.AutoConnect(conn)()
-		result := msg.(types.ConnectedMsg)
-		if result.Err != nil {
-			t.Errorf("unexpected error: %v", result.Err)
-		}
-		if len(mock.Calls) == 0 || mock.Calls[0] != "ConnectCluster" {
-			t.Errorf("expected ConnectCluster call, got %v", mock.Calls)
-		}
-	})
-
-	t.Run("success TLS", func(t *testing.T) {
-		cmds, mock := newMockCmds()
-		conn := types.Connection{
-			Host:   "localhost",
-			Port:   6380,
-			UseTLS: true,
-			TLSConfig: &types.TLSConfig{
-				InsecureSkipVerify: true,
-			},
-		}
-		msg := cmds.AutoConnect(conn)()
-		result := msg.(types.ConnectedMsg)
-		if result.Err != nil {
-			t.Errorf("unexpected error: %v", result.Err)
-		}
-		if len(mock.Calls) == 0 || mock.Calls[0] != "ConnectWithTLS" {
-			t.Errorf("expected ConnectWithTLS call, got %v", mock.Calls)
-		}
-	})
-
-	t.Run("TLS without config returns error", func(t *testing.T) {
-		cmds, _ := newMockCmds()
-		conn := types.Connection{Host: "localhost", Port: 6379, UseTLS: true}
-		msg := cmds.AutoConnect(conn)()
-		result := msg.(types.ConnectedMsg)
-		if result.Err == nil {
-			t.Error("expected error for TLS without config")
-		}
-		if result.Err.Error() != "TLS requested but TLS configuration is missing" {
-			t.Errorf("unexpected error message: %v", result.Err)
-		}
-	})
-
-	t.Run("TLS bad cert file", func(t *testing.T) {
-		cmds, _ := newMockCmds()
-		conn := types.Connection{
-			Host:   "localhost",
-			Port:   6380,
-			UseTLS: true,
-			TLSConfig: &types.TLSConfig{
-				CertFile: "/nonexistent/cert.pem",
-				KeyFile:  "/nonexistent/key.pem",
-			},
-		}
-		msg := cmds.AutoConnect(conn)()
-		result := msg.(types.ConnectedMsg)
-		if result.Err == nil {
-			t.Error("expected error for bad TLS cert file")
-		}
-	})
-
-	t.Run("connect error", func(t *testing.T) {
-		cmds, mock := newMockCmds()
-		mock.ConnectError = errors.New("connection refused")
-		conn := types.Connection{Host: "localhost", Port: 6379}
-		msg := cmds.AutoConnect(conn)()
-		result := msg.(types.ConnectedMsg)
-		if result.Err == nil {
-			t.Error("expected error")
-		}
-	})
-
-	t.Run("cluster error", func(t *testing.T) {
-		cmds, mock := newMockCmds()
-		mock.ConnectClusterError = errors.New("cluster unavailable")
-		conn := types.Connection{Host: "localhost", Port: 7000, UseCluster: true}
-		msg := cmds.AutoConnect(conn)()
-		result := msg.(types.ConnectedMsg)
-		if result.Err == nil {
-			t.Error("expected error")
-		}
-	})
-
-	t.Run("TLS connect error", func(t *testing.T) {
-		cmds, mock := newMockCmds()
-		mock.ConnectWithTLSError = errors.New("TLS handshake failed")
-		conn := types.Connection{
-			Host:      "localhost",
-			Port:      6380,
-			UseTLS:    true,
-			TLSConfig: &types.TLSConfig{InsecureSkipVerify: true},
-		}
-		msg := cmds.AutoConnect(conn)()
-		result := msg.(types.ConnectedMsg)
-		if result.Err == nil {
-			t.Error("expected error")
-		}
-	})
-
-	t.Run("nil redis", func(t *testing.T) {
-		cmds := NewCommands(nil, nil)
-		conn := types.Connection{Host: "localhost", Port: 6379}
-		msg := cmds.AutoConnect(conn)()
-		result := msg.(types.ConnectedMsg)
-		if result.Err != nil {
-			t.Errorf("nil redis should not error: %v", result.Err)
-		}
-	})
-}
-
-func TestAutoConnect_ClusterWithTLS_IgnoresTLS(t *testing.T) {
-	// Documents current behavior: when both UseCluster and UseTLS are set,
-	// the cluster branch runs first and TLS is silently ignored.
-	// This test guards against accidental changes and documents the gap.
-	cmds, mock := newMockCmds()
-	conn := types.Connection{
-		Host:       "localhost",
-		Port:       7000,
-		UseCluster: true,
-		UseTLS:     true,
-		TLSConfig:  &types.TLSConfig{InsecureSkipVerify: true},
-	}
-	msg := cmds.AutoConnect(conn)()
-	result := msg.(types.ConnectedMsg)
-	if result.Err != nil {
-		t.Errorf("unexpected error: %v", result.Err)
-	}
-	// Cluster path takes priority — ConnectCluster is called, not ConnectWithTLS
-	if len(mock.Calls) == 0 || mock.Calls[0] != "ConnectCluster" {
-		t.Errorf("expected ConnectCluster call (cluster takes priority over TLS), got %v", mock.Calls)
-	}
 }
 
 func TestDisconnect(t *testing.T) {
@@ -370,7 +220,7 @@ func TestTestConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
 		mock.TestConnectionLatency = 5 * time.Millisecond
-		msg := cmds.TestConnection("localhost", 6379, "", 0)()
+		msg := cmds.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionTestMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
@@ -386,7 +236,7 @@ func TestTestConnection(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		cmds, mock := newMockCmds()
 		mock.TestConnectionError = errors.New("connection failed")
-		msg := cmds.TestConnection("localhost", 6379, "", 0)()
+		msg := cmds.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionTestMsg)
 		if result.Err == nil {
 			t.Error("expected error")
@@ -398,7 +248,7 @@ func TestTestConnection(t *testing.T) {
 
 	t.Run("nil redis", func(t *testing.T) {
 		cmds := NewCommands(nil, nil)
-		msg := cmds.TestConnection("localhost", 6379, "", 0)()
+		msg := cmds.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionTestMsg)
 		if result.Err != nil {
 			t.Errorf("nil redis should not error: %v", result.Err)

--- a/internal/cmd/commands_connection_test.go
+++ b/internal/cmd/commands_connection_test.go
@@ -196,6 +196,15 @@ func TestConnect(t *testing.T) {
 			t.Errorf("nil redis should not error: %v", result.Err)
 		}
 	})
+
+	t.Run("nil conn", func(t *testing.T) {
+		cmds := NewCommands(nil, nil)
+		msg := cmds.Connect(nil)()
+		result := msg.(types.ConnectedMsg)
+		if result.Err != nil {
+			t.Errorf("nil redis should not error: %v", result.Err)
+		}
+	})
 }
 
 func TestDisconnect(t *testing.T) {
@@ -249,6 +258,15 @@ func TestTestConnection(t *testing.T) {
 	t.Run("nil redis", func(t *testing.T) {
 		cmds := NewCommands(nil, nil)
 		msg := cmds.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
+		result := msg.(types.ConnectionTestMsg)
+		if result.Err != nil {
+			t.Errorf("nil redis should not error: %v", result.Err)
+		}
+	})
+
+	t.Run("nil conn", func(t *testing.T) {
+		cmds := NewCommands(nil, nil)
+		msg := cmds.TestConnection(nil)()
 		result := msg.(types.ConnectionTestMsg)
 		if result.Err != nil {
 			t.Errorf("nil redis should not error: %v", result.Err)

--- a/internal/cmd/commands_keys_test.go
+++ b/internal/cmd/commands_keys_test.go
@@ -11,7 +11,7 @@ import (
 func TestLoadKeys(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect("localhost", 6379, "", 0)
+		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		mock.SetKey("k1", types.RedisValue{}, types.KeyTypeString, 0)
 		msg := cmds.LoadKeys("*", 0, 100)()
 		result := msg.(types.KeysLoadedMsg)
@@ -36,7 +36,7 @@ func TestLoadKeys(t *testing.T) {
 func TestLoadKeyValue(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect("localhost", 6379, "", 0)
+		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		mock.SetKey("mykey", types.RedisValue{Type: types.KeyTypeString, StringValue: "val"}, types.KeyTypeString, 0)
 		msg := cmds.LoadKeyValue("mykey")()
 		result := msg.(types.KeyValueLoadedMsg)
@@ -88,7 +88,7 @@ func TestLoadKeyPreview(t *testing.T) {
 func TestDeleteKey(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect("localhost", 6379, "", 0)
+		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.DeleteKey("mykey")()
 		result := msg.(types.KeyDeletedMsg)
 		if result.Err != nil {
@@ -160,7 +160,7 @@ func TestCreateKey(t *testing.T) {
 	for _, tt := range keyTypes {
 		t.Run(tt.name, func(t *testing.T) {
 			cmds, mock := newMockCmds()
-			_ = mock.Connect("localhost", 6379, "", 0)
+			_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 			msg := cmds.CreateKey("newkey", tt.keyType, tt.value, tt.extra, 0)()
 			result := msg.(types.KeySetMsg)
 			if result.Err != nil {
@@ -174,7 +174,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("zset with empty extra defaults to 0", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect("localhost", 6379, "", 0)
+		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("zkey", types.KeyTypeZSet, "member", "", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err != nil {
@@ -184,7 +184,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("hash with empty extra defaults to 'field'", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect("localhost", 6379, "", 0)
+		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("hkey", types.KeyTypeHash, "val", "", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err != nil {
@@ -194,7 +194,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("stream with empty extra defaults to 'data'", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect("localhost", 6379, "", 0)
+		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("skey", types.KeyTypeStream, "val", "", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err != nil {

--- a/internal/cmd/commands_keys_test.go
+++ b/internal/cmd/commands_keys_test.go
@@ -11,7 +11,7 @@ import (
 func TestLoadKeys(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		mock.SetKey("k1", types.RedisValue{}, types.KeyTypeString, 0)
 		msg := cmds.LoadKeys("*", 0, 100)()
 		result := msg.(types.KeysLoadedMsg)
@@ -36,7 +36,7 @@ func TestLoadKeys(t *testing.T) {
 func TestLoadKeyValue(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		mock.SetKey("mykey", types.RedisValue{Type: types.KeyTypeString, StringValue: "val"}, types.KeyTypeString, 0)
 		msg := cmds.LoadKeyValue("mykey")()
 		result := msg.(types.KeyValueLoadedMsg)
@@ -64,7 +64,7 @@ func TestLoadKeyValue(t *testing.T) {
 func TestLoadKeyPreview(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		mock.SetKey("pk", types.RedisValue{Type: types.KeyTypeString, StringValue: "preview"}, types.KeyTypeString, 0)
 		msg := cmds.LoadKeyPreview("pk")()
 		result := msg.(types.KeyPreviewLoadedMsg)
@@ -88,7 +88,7 @@ func TestLoadKeyPreview(t *testing.T) {
 func TestDeleteKey(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.DeleteKey("mykey")()
 		result := msg.(types.KeyDeletedMsg)
 		if result.Err != nil {
@@ -160,7 +160,7 @@ func TestCreateKey(t *testing.T) {
 	for _, tt := range keyTypes {
 		t.Run(tt.name, func(t *testing.T) {
 			cmds, mock := newMockCmds()
-			_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+			_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 			msg := cmds.CreateKey("newkey", tt.keyType, tt.value, tt.extra, 0)()
 			result := msg.(types.KeySetMsg)
 			if result.Err != nil {
@@ -174,7 +174,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("zset with empty extra defaults to 0", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("zkey", types.KeyTypeZSet, "member", "", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err != nil {
@@ -184,7 +184,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("hash with empty extra defaults to 'field'", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("hkey", types.KeyTypeHash, "val", "", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err != nil {
@@ -194,7 +194,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("stream with empty extra defaults to 'data'", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("skey", types.KeyTypeStream, "val", "", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err != nil {
@@ -213,7 +213,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("zset invalid score", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("zk", types.KeyTypeZSet, "member", "not-a-number", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err == nil {
@@ -223,7 +223,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("json type", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_ = mock.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("jk", types.KeyTypeJSON, `{"a":1}`, "", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err != nil {

--- a/internal/cmd/commands_keys_test.go
+++ b/internal/cmd/commands_keys_test.go
@@ -64,7 +64,7 @@ func TestLoadKeyValue(t *testing.T) {
 func TestLoadKeyPreview(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect("localhost", 6379, "", 0)
+		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		mock.SetKey("pk", types.RedisValue{Type: types.KeyTypeString, StringValue: "preview"}, types.KeyTypeString, 0)
 		msg := cmds.LoadKeyPreview("pk")()
 		result := msg.(types.KeyPreviewLoadedMsg)
@@ -213,7 +213,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("zset invalid score", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect("localhost", 6379, "", 0)
+		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("zk", types.KeyTypeZSet, "member", "not-a-number", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err == nil {
@@ -223,7 +223,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("json type", func(t *testing.T) {
 		cmds, mock := newMockCmds()
-		_ = mock.Connect("localhost", 6379, "", 0)
+		_ = mock.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		msg := cmds.CreateKey("jk", types.KeyTypeJSON, `{"a":1}`, "", 0)()
 		result := msg.(types.KeySetMsg)
 		if result.Err != nil {

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -47,7 +47,7 @@ func NewConfig(configPath string) (*Config, error) {
 
 	// Ensure directory exists
 	dir := filepath.Dir(configPath)
-	if err := os.MkdirAll(dir, 0750); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return nil, err
 	}
 
@@ -149,7 +149,7 @@ func (c *Config) save() error {
 		return err
 	}
 
-	return os.WriteFile(c.path, data, 0600)
+	return os.WriteFile(c.path, data, 0o600)
 }
 
 func (c *Config) Close() error {
@@ -170,64 +170,56 @@ func (c *Config) ListConnections() ([]types.Connection, error) {
 	return result, nil
 }
 
-func (c *Config) AddConnection(name, host string, port int, password string, db int, useCluster bool) (types.Connection, error) {
+func (c *Config) AddConnection(conn types.Connection) (types.Connection, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	now := time.Now()
-	conn := types.Connection{
-		ID:         c.nextID,
-		Name:       name,
-		Host:       host,
-		Port:       port,
-		Password:   password,
-		DB:         db,
-		UseCluster: useCluster,
-		Created:    now,
-		Updated:    now,
-	}
-	c.nextID++
+
+	conn.Created = now
+	conn.Updated = now
 
 	c.Connections = append(c.Connections, conn)
 
 	if err := c.save(); err != nil {
 		c.Connections = c.Connections[:len(c.Connections)-1]
-		c.nextID--
 		return types.Connection{}, err
 	}
 
-	return conn, nil
+	addedConnection := c.Connections[len(c.Connections)-1]
+
+	return addedConnection, nil
 }
 
-func (c *Config) UpdateConnection(id int64, name, host string, port int, password string, db int, useCluster bool) (types.Connection, error) {
+func (c *Config) UpdateConnection(conn types.Connection) (types.Connection, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for i, conn := range c.Connections {
-		if conn.ID == id {
+	for i, toUpdateConn := range c.Connections {
+		if toUpdateConn.ID == conn.ID {
 			now := time.Now()
 			updatedConn := types.Connection{
-				ID:         id,
-				Name:       name,
-				Host:       host,
-				Port:       port,
-				Password:   password,
-				DB:         db,
-				Group:      conn.Group,
-				Color:      conn.Color,
-				UseSSH:     conn.UseSSH,
-				SSHConfig:  conn.SSHConfig,
-				UseTLS:     conn.UseTLS,
-				TLSConfig:  conn.TLSConfig,
-				UseCluster: useCluster,
-				Created:    conn.Created,
+				ID:         conn.ID,
+				Name:       conn.Name,
+				Host:       conn.Host,
+				Port:       conn.Port,
+				Password:   conn.Password,
+				DB:         conn.DB,
+				Group:      toUpdateConn.Group,
+				Color:      toUpdateConn.Color,
+				UseSSH:     toUpdateConn.UseSSH,
+				SSHConfig:  toUpdateConn.SSHConfig,
+				UseTLS:     toUpdateConn.UseTLS,
+				TLSConfig:  toUpdateConn.TLSConfig,
+				UseCluster: conn.UseCluster,
+				Created:    toUpdateConn.Created,
 				Updated:    now,
 			}
 
 			c.Connections[i] = updatedConn
 
 			if err := c.save(); err != nil {
-				c.Connections[i] = conn // Rollback
+				c.Connections[i] = toUpdateConn // Rollback
 				return types.Connection{}, err
 			}
 

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -176,13 +176,17 @@ func (c *Config) AddConnection(conn types.Connection) (types.Connection, error) 
 
 	now := time.Now()
 
+	conn.ID = c.nextID
 	conn.Created = now
 	conn.Updated = now
+
+	c.nextID++
 
 	c.Connections = append(c.Connections, conn)
 
 	if err := c.save(); err != nil {
 		c.Connections = c.Connections[:len(c.Connections)-1]
+		c.nextID--
 		return types.Connection{}, err
 	}
 

--- a/internal/db/config_coverage_test.go
+++ b/internal/db/config_coverage_test.go
@@ -20,7 +20,7 @@ func TestNewConfig_MkdirError(t *testing.T) {
 	// Create a file where a directory is expected to force MkdirAll to fail.
 	dir := t.TempDir()
 	blocker := filepath.Join(dir, "blocker")
-	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
 		t.Fatalf("setup failed: %v", err)
 	}
 	// configPath points to a file nested under the blocker file — MkdirAll
@@ -35,7 +35,7 @@ func TestNewConfig_LoadError(t *testing.T) {
 	// Write an invalid JSON file so load() returns a non-IsNotExist error.
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
-	if err := os.WriteFile(configPath, []byte("not json at all"), 0600); err != nil {
+	if err := os.WriteFile(configPath, []byte("not json at all"), 0o600); err != nil {
 		t.Fatalf("setup failed: %v", err)
 	}
 	if _, err := NewConfig(configPath); err == nil {
@@ -159,14 +159,14 @@ func TestConfig_SaveRollback(t *testing.T) {
 
 	// Replace the config path with a directory so subsequent save()s fail.
 	badPath := filepath.Join(dir, "nowdir")
-	if err := os.Mkdir(badPath, 0750); err != nil {
+	if err := os.Mkdir(badPath, 0o750); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
 	}
 	cfg.path = badPath
 
 	t.Run("AddConnection rollback", func(t *testing.T) {
 		before := len(cfg.Connections)
-		if _, err := cfg.AddConnection("x", "h", 1, "", 0, false); err == nil {
+		if _, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false}); err == nil {
 			t.Error("expected save error")
 		}
 		if got := len(cfg.Connections); got != before {
@@ -193,19 +193,25 @@ func TestConfig_UpdateConnection_SaveError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewConfig failed: %v", err)
 	}
-	conn, err := cfg.AddConnection("orig", "h", 1, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "orig", Host: "h", Port: 1, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
 
 	// Break save() by pointing path to a directory.
 	badPath := filepath.Join(dir, "blocked")
-	if err := os.Mkdir(badPath, 0750); err != nil {
+	if err := os.Mkdir(badPath, 0o750); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
 	}
 	cfg.path = badPath
 
-	if _, err := cfg.UpdateConnection(conn.ID, "new", "h2", 2, "", 0, false); err == nil {
+	conn.Name = "new"
+	conn.Host = "h2"
+	conn.Port = 2
+	conn.DB = 0
+	conn.UseCluster = false
+
+	if _, err := cfg.UpdateConnection(conn); err == nil {
 		t.Error("expected save error")
 	}
 	if cfg.Connections[0].Name != "orig" {

--- a/internal/db/config_features_test.go
+++ b/internal/db/config_features_test.go
@@ -198,7 +198,7 @@ func TestConfig_Persistence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewConfig failed: %v", err)
 	}
-	_, err = cfg1.AddConnection("test", "localhost", 6379, "pass", 0, false)
+	_, err = cfg1.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestConfig_Groups(t *testing.T) {
 	}
 
 	// Add connection to group
-	conn, errConn := cfg.AddConnection("test", "localhost", 6379, "", 0, false)
+	conn, errConn := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if errConn != nil {
 		t.Fatalf("AddConnection failed: %v", errConn)
 	}

--- a/internal/db/config_integrity_test.go
+++ b/internal/db/config_integrity_test.go
@@ -18,7 +18,7 @@ func TestConfig_Integration_FullConnectionLifecycle(t *testing.T) {
 	cfg := newTestConfig(t)
 
 	// Step 1: Add a connection with all features
-	conn, err := cfg.AddConnection("prod", "redis.example.com", 6380, "secret", 2, true)
+	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -101,7 +101,12 @@ func TestConfig_Integration_FullConnectionLifecycle(t *testing.T) {
 	}
 
 	// Step 3: Update the connection and verify preserved fields
-	updated, err := cfg2.UpdateConnection(got.ID, "prod-updated", "redis2.example.com", 6381, "", 3, false)
+	got.Name = "prod-updated"
+	got.Host = "redis2.example.com"
+	got.Port = 6381
+	got.DB = 3
+	got.UseCluster = false
+	updated, err := cfg2.UpdateConnection(got)
 	if err != nil {
 		t.Fatalf("UpdateConnection failed: %v", err)
 	}
@@ -151,7 +156,7 @@ func TestConfig_CorruptedJSON(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 
 	// Write invalid JSON
-	err := os.WriteFile(path, []byte(`{broken json!!!`), 0600)
+	err := os.WriteFile(path, []byte(`{broken json!!!`), 0o600)
 	if err != nil {
 		t.Fatalf("failed to write corrupt config: %v", err)
 	}
@@ -166,7 +171,7 @@ func TestConfig_EmptyFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
 
-	err := os.WriteFile(path, []byte(``), 0600)
+	err := os.WriteFile(path, []byte(``), 0o600)
 	if err != nil {
 		t.Fatalf("failed to write empty config: %v", err)
 	}
@@ -182,15 +187,15 @@ func TestConfig_NextID_AfterReload(t *testing.T) {
 	cfg := newTestConfig(t)
 
 	// Add 3 connections, IDs should be 1, 2, 3
-	conn1, err := cfg.AddConnection("a", "localhost", 6379, "", 0, false)
+	conn1, err := cfg.AddConnection(types.Connection{Name: "a", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
-	_, err = cfg.AddConnection("b", "localhost", 6380, "", 0, false)
+	_, err = cfg.AddConnection(types.Connection{Name: "b", Host: "localhost", Port: 6380, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
-	conn3, err := cfg.AddConnection("c", "localhost", 6381, "", 0, false)
+	conn3, err := cfg.AddConnection(types.Connection{Name: "c", Host: "localhost", Port: 6381, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -205,7 +210,7 @@ func TestConfig_NextID_AfterReload(t *testing.T) {
 	cfg2 := reloadConfig(t, cfg)
 
 	// Add a new connection — its ID must be higher than conn3
-	conn4, err := cfg2.AddConnection("d", "localhost", 6382, "", 0, false)
+	conn4, err := cfg2.AddConnection(types.Connection{Name: "d", Host: "localhost", Port: 6382, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection after reload failed: %v", err)
 	}
@@ -225,7 +230,7 @@ func TestConfig_NextID_WithGaps(t *testing.T) {
 			{"id": 100, "name": "high-id", "host": "localhost", "port": 6379, "db": 0, "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z"}
 		]
 	}`
-	err := os.WriteFile(path, []byte(raw), 0600)
+	err := os.WriteFile(path, []byte(raw), 0o600)
 	if err != nil {
 		t.Fatalf("failed to write config: %v", err)
 	}
@@ -235,7 +240,7 @@ func TestConfig_NextID_WithGaps(t *testing.T) {
 		t.Fatalf("NewConfig failed: %v", err)
 	}
 
-	conn, err := cfg.AddConnection("new", "localhost", 6380, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "new", Host: "localhost", Port: 6380, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -250,7 +255,7 @@ func TestConfig_ConcurrentReadWrite(t *testing.T) {
 
 	// Seed some data
 	for i := range 5 {
-		_, err := cfg.AddConnection("conn"+string(rune('a'+i)), "localhost", 6379+i, "", 0, false)
+		_, err := cfg.AddConnection(types.Connection{Name: "conn" + string(rune('a'+i)), Host: "localhost", Port: 6379 + i, DB: 0, UseCluster: false})
 		if err != nil {
 			t.Fatalf("AddConnection failed: %v", err)
 		}
@@ -310,7 +315,7 @@ func TestConfig_ConcurrentAddDelete(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			conn, err := cfg.AddConnection("concurrent"+string(rune('a'+i)), "localhost", 6379+i, "", 0, false)
+			conn, err := cfg.AddConnection(types.Connection{Name: "concurrent" + string(rune('a'+i)), Host: "localhost", Port: 6379 + i, DB: 0, UseCluster: false})
 			if err != nil {
 				return
 			}
@@ -340,7 +345,7 @@ func TestConfig_ConcurrentAddDelete(t *testing.T) {
 func TestConfig_DeleteConnection_OrphanedFavorites(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("test", "localhost", 6379, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}

--- a/internal/db/config_integrity_test.go
+++ b/internal/db/config_integrity_test.go
@@ -18,7 +18,7 @@ func TestConfig_Integration_FullConnectionLifecycle(t *testing.T) {
 	cfg := newTestConfig(t)
 
 	// Step 1: Add a connection with all features
-	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+	conn, err := cfg.AddConnection(types.Connection{Name: "prod", Host: "redis.example.com", Port: 6380, DB: 2, UseCluster: true})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}

--- a/internal/db/config_persistence_test.go
+++ b/internal/db/config_persistence_test.go
@@ -14,7 +14,7 @@ import (
 func TestConfig_Persistence_AllConnectionFields(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("prod-redis", "redis.example.com", 6380, "", 2, true)
+	conn, err := cfg.AddConnection(types.Connection{Name: "prod-redis", Host: "redis.example.com", Port: 6380, DB: 2, UseCluster: true})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestConfig_Persistence_AllConnectionFields(t *testing.T) {
 func TestConfig_Persistence_PasswordStripping(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("secure", "localhost", 6379, "s3cr3t_p@ss", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "secure", Host: "localhost", Port: 6379, Password: "s3cr3t_p@ss", DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestConfig_PasswordFieldCanBeLoaded(t *testing.T) {
 			"updated_at": "2025-01-01T00:00:00Z"
 		}]
 	}`
-	err := os.WriteFile(path, []byte(raw), 0600)
+	err := os.WriteFile(path, []byte(raw), 0o600)
 	if err != nil {
 		t.Fatalf("failed to write config file: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestConfig_SSHPasswordFieldCanBeLoaded(t *testing.T) {
 			"updated_at": "2025-01-01T00:00:00Z"
 		}]
 	}`
-	err := os.WriteFile(path, []byte(raw), 0600)
+	err := os.WriteFile(path, []byte(raw), 0o600)
 	if err != nil {
 		t.Fatalf("failed to write config file: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestConfig_SSHPasswordFieldCanBeLoaded(t *testing.T) {
 func TestConfig_Persistence_SSHPasswordStripping(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("ssh-conn", "localhost", 6379, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "ssh-conn", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestConfig_Persistence_SSHPasswordStripping(t *testing.T) {
 func TestConfig_Persistence_TLSConfig(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("tls-conn", "localhost", 6380, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "tls-conn", Host: "localhost", Port: 6380, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -325,7 +325,7 @@ func TestConfig_Persistence_TLSConfig(t *testing.T) {
 func TestConfig_UpdateConnection_PreservesGroupAndColor(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("test", "localhost", 6379, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -341,7 +341,13 @@ func TestConfig_UpdateConnection_PreservesGroupAndColor(t *testing.T) {
 	cfg.mu.Unlock()
 
 	// Update basic fields
-	updated, err := cfg.UpdateConnection(conn.ID, "renamed", "newhost", 6380, "pass", 1, false)
+	conn.Name = "renamed"
+	conn.Host = "newhost"
+	conn.Port = 6380
+	conn.Password = "pass"
+	conn.DB = 1
+	conn.UseCluster = false
+	updated, err := cfg.UpdateConnection(conn)
 	if err != nil {
 		t.Fatalf("UpdateConnection failed: %v", err)
 	}
@@ -357,7 +363,7 @@ func TestConfig_UpdateConnection_PreservesGroupAndColor(t *testing.T) {
 func TestConfig_UpdateConnection_PreservesSSH(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("test", "localhost", 6379, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -377,7 +383,11 @@ func TestConfig_UpdateConnection_PreservesSSH(t *testing.T) {
 	}
 	cfg.mu.Unlock()
 
-	updated, err := cfg.UpdateConnection(conn.ID, "renamed", "newhost", 6380, "", 0, false)
+	conn.Name = "renamed"
+	conn.Host = "newhost"
+	conn.Port = 6380
+	conn.DB = 0
+	updated, err := cfg.UpdateConnection(conn)
 	if err != nil {
 		t.Fatalf("UpdateConnection failed: %v", err)
 	}
@@ -399,7 +409,7 @@ func TestConfig_UpdateConnection_PreservesSSH(t *testing.T) {
 func TestConfig_UpdateConnection_PreservesTLS(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("test", "localhost", 6379, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -420,7 +430,11 @@ func TestConfig_UpdateConnection_PreservesTLS(t *testing.T) {
 	}
 	cfg.mu.Unlock()
 
-	updated, err := cfg.UpdateConnection(conn.ID, "renamed", "newhost", 6380, "", 0, false)
+	conn.Name = "renamed"
+	conn.Host = "newhost"
+	conn.Port = 6380
+	conn.DB = 0
+	updated, err := cfg.UpdateConnection(conn)
 	if err != nil {
 		t.Fatalf("UpdateConnection failed: %v", err)
 	}
@@ -444,7 +458,7 @@ func TestConfig_UpdateConnection_PreservesTLS(t *testing.T) {
 func TestConfig_Persistence_Favorites(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	_, err := cfg.AddConnection("test", "localhost", 6379, "", 0, false)
+	_, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -522,7 +536,7 @@ func TestConfig_Persistence_Groups(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddGroup failed: %v", err)
 	}
-	conn, err := cfg.AddConnection("test", "localhost", 6379, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}

--- a/internal/db/config_test.go
+++ b/internal/db/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -83,15 +85,15 @@ func TestConfig_AddConnection(t *testing.T) {
 func TestConfig_AddConnection_IncrementingIDs(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn1, err := cfg.AddConnection("test1", "localhost", 6379, "", 0, false)
+	conn1, err := cfg.AddConnection(types.Connection{Name: "test1", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
-	conn2, err := cfg.AddConnection("test2", "localhost", 6380, "", 0, false)
+	conn2, err := cfg.AddConnection(types.Connection{Name: "test2", Host: "localhost", Port: 6380, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
-	conn3, err := cfg.AddConnection("test3", "localhost", 6381, "", 0, false)
+	conn3, err := cfg.AddConnection(types.Connection{Name: "test3", Host: "localhost", Port: 6381, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -108,15 +110,15 @@ func TestConfig_ListConnections(t *testing.T) {
 	cfg := newTestConfig(t)
 
 	// Add connections in non-alphabetical order
-	_, err := cfg.AddConnection("zebra", "localhost", 6379, "", 0, false)
+	_, err := cfg.AddConnection(types.Connection{Name: "zebra", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
-	_, err = cfg.AddConnection("alpha", "localhost", 6380, "", 0, false)
+	_, err = cfg.AddConnection(types.Connection{Name: "alpha", Host: "localhost", Port: 6380, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
-	_, err = cfg.AddConnection("beta", "localhost", 6381, "", 0, false)
+	_, err = cfg.AddConnection(types.Connection{Name: "beta", Host: "localhost", Port: 6381, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -145,7 +147,7 @@ func TestConfig_ListConnections(t *testing.T) {
 func TestConfig_UpdateConnection(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("original", "localhost", 6379, "old", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "original", Host: "localhost", Port: 6379, Password: "old", DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -196,7 +198,7 @@ func TestConfig_UpdateConnection_NotFound(t *testing.T) {
 func TestConfig_DeleteConnection(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("test", "localhost", 6379, "", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}

--- a/internal/db/config_test.go
+++ b/internal/db/config_test.go
@@ -52,7 +52,7 @@ func TestNewConfig_CreatesDirectory(t *testing.T) {
 func TestConfig_AddConnection(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection("test", "localhost", 6379, "secret", 0, false)
+	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "secret", DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -150,8 +150,13 @@ func TestConfig_UpdateConnection(t *testing.T) {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
 	originalCreated := conn.Created
+	conn.Name = "updated"
+	conn.Host = "newhost"
+	conn.Port = 6380
+	conn.Password = "new"
+	conn.DB = 1
 
-	updated, err := cfg.UpdateConnection(conn.ID, "updated", "newhost", 6380, "new", 1, false)
+	updated, err := cfg.UpdateConnection(conn)
 	if err != nil {
 		t.Fatalf("UpdateConnection failed: %v", err)
 	}
@@ -182,7 +187,7 @@ func TestConfig_UpdateConnection(t *testing.T) {
 func TestConfig_UpdateConnection_NotFound(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	_, err := cfg.UpdateConnection(999, "test", "localhost", 6379, "", 0, false)
+	_, err := cfg.UpdateConnection(types.Connection{ID: 999, Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 	if !os.IsNotExist(err) {
 		t.Errorf("Expected os.ErrNotExist, got %v", err)
 	}

--- a/internal/redis/client_test.go
+++ b/internal/redis/client_test.go
@@ -189,7 +189,7 @@ func TestScanAll_NonClusterScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -213,7 +213,7 @@ func TestScanEach_NonClusterScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/client_test.go
+++ b/internal/redis/client_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
 func TestFuzzyScore(t *testing.T) {
@@ -187,7 +189,7 @@ func TestScanAll_NonClusterScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -211,7 +213,7 @@ func TestScanEach_NonClusterScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/connection.go
+++ b/internal/redis/connection.go
@@ -23,10 +23,7 @@ const (
 	defaultPingTimeout  = 5 * time.Second
 )
 
-func defaultOptions(conn *types.Connection) *redis.Options {
-	if conn == nil {
-		return nil
-	}
+func defaultOptions(conn types.Connection) *redis.Options {
 	return &redis.Options{
 		Addr:         fmt.Sprintf("%s:%d", conn.Host, conn.Port),
 		Password:     conn.Password,
@@ -48,12 +45,8 @@ func (c *Client) cleanup() {
 }
 
 // Connect establishes a connection to Redis
-func (c *Client) Connect(conn *types.Connection) error {
+func (c *Client) Connect(conn types.Connection) error {
 	c.cleanup()
-
-	if conn == nil {
-		return fmt.Errorf("connection is nil")
-	}
 
 	opts := defaultOptions(conn)
 	if conn.UseTLS {
@@ -85,12 +78,8 @@ func (c *Client) Connect(conn *types.Connection) error {
 }
 
 // ConnectCluster establishes a connection to a Redis cluster
-func (c *Client) ConnectCluster(addrs []string, conn *types.Connection) error {
+func (c *Client) ConnectCluster(addrs []string, conn types.Connection) error {
 	c.cleanup()
-
-	if conn == nil {
-		return fmt.Errorf("connection is nil")
-	}
 
 	// Parse first address for display purposes
 	seedHost := "127.0.0.1"
@@ -225,11 +214,7 @@ func (c *Client) SelectDB(db int) error {
 }
 
 // TestConnection tests a connection
-func (c *Client) TestConnection(conn *types.Connection) (time.Duration, error) {
-	if conn == nil {
-		return 0, fmt.Errorf("connection is nil")
-	}
-
+func (c *Client) TestConnection(conn types.Connection) (time.Duration, error) {
 	opts := defaultOptions(conn)
 	if conn.UseTLS {
 		if conn.TLSConfig == nil {

--- a/internal/redis/connection.go
+++ b/internal/redis/connection.go
@@ -101,7 +101,7 @@ func (c *Client) ConnectCluster(addrs []string, conn *types.Connection) error {
 		seedHost = host
 	}
 
-	cluster := redis.NewClusterClient(&redis.ClusterOptions{
+	opts := &redis.ClusterOptions{
 		Addrs:        addrs,
 		Password:     conn.Password,
 		DialTimeout:  defaultDialTimeout,
@@ -111,17 +111,30 @@ func (c *Client) ConnectCluster(addrs []string, conn *types.Connection) error {
 		MinIdleConns: defaultMinIdleConns,
 		MaxRetries:   defaultMaxRetries,
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			_, port, err := net.SplitHostPort(addr)
+			_, p, err := net.SplitHostPort(addr)
 			if err != nil {
 				return nil, err
 			}
-			return net.DialTimeout(network, net.JoinHostPort(seedHost, port), defaultDialTimeout)
+			return net.DialTimeout(network, net.JoinHostPort(seedHost, p), defaultDialTimeout)
 		},
-	})
+	}
+
+	if conn.UseTLS {
+		if conn.TLSConfig == nil {
+			return fmt.Errorf("TLS requested but TLS configuration is missing")
+		}
+		tlsCfg, err := conn.TLSConfig.BuildTLSConfig()
+		if err != nil {
+			return fmt.Errorf("failed to build TLS config: %w", err)
+		}
+		opts.TLSConfig = tlsCfg
+	}
+
+	cluster := redis.NewClusterClient(opts)
 
 	c.mu.Lock()
 	c.isCluster = true
-	c.password = conn.Password // ClusterClient does not support passwords
+	c.password = conn.Password
 	c.host = host
 	c.port = port
 	c.cluster = cluster
@@ -213,10 +226,22 @@ func (c *Client) SelectDB(db int) error {
 
 // TestConnection tests a connection
 func (c *Client) TestConnection(conn *types.Connection) (time.Duration, error) {
-	testClient := redis.NewClient(defaultOptions(conn))
 	if conn == nil {
 		return 0, fmt.Errorf("connection is nil")
 	}
+
+	opts := defaultOptions(conn)
+	if conn.UseTLS {
+		if conn.TLSConfig == nil {
+			return 0, fmt.Errorf("TLS requested but TLS configuration is missing")
+		}
+		tslCfg, err := conn.TLSConfig.BuildTLSConfig()
+		if err != nil {
+			return 0, err
+		}
+		opts.TLSConfig = tslCfg
+	}
+	testClient := redis.NewClient(opts)
 	defer testClient.Close()
 
 	start := time.Now()

--- a/internal/redis/connection.go
+++ b/internal/redis/connection.go
@@ -78,7 +78,7 @@ func (c *Client) Connect(conn *types.Connection) error {
 }
 
 // ConnectCluster establishes a connection to a Redis cluster
-func (c *Client) ConnectCluster(addrs []string, password string) error {
+func (c *Client) ConnectCluster(addrs []string, conn *types.Connection) error {
 	c.cleanup()
 
 	// Parse first address for display purposes
@@ -92,7 +92,7 @@ func (c *Client) ConnectCluster(addrs []string, password string) error {
 
 	cluster := redis.NewClusterClient(&redis.ClusterOptions{
 		Addrs:        addrs,
-		Password:     password,
+		Password:     conn.Password,
 		DialTimeout:  defaultDialTimeout,
 		ReadTimeout:  defaultReadTimeout,
 		WriteTimeout: defaultWriteTimeout,
@@ -110,7 +110,7 @@ func (c *Client) ConnectCluster(addrs []string, password string) error {
 
 	c.mu.Lock()
 	c.isCluster = true
-	c.password = password
+	c.password = conn.Password // ClusterClient does not support passwords
 	c.host = host
 	c.port = port
 	c.cluster = cluster

--- a/internal/redis/connection.go
+++ b/internal/redis/connection.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -10,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davidbudnick/redis-tui/internal/types"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -23,11 +23,11 @@ const (
 	defaultPingTimeout  = 5 * time.Second
 )
 
-func defaultOptions(addr, password string, db int) *redis.Options {
+func defaultOptions(conn *types.Connection) *redis.Options {
 	return &redis.Options{
-		Addr:         addr,
-		Password:     password,
-		DB:           db,
+		Addr:         fmt.Sprintf("%s:%d", conn.Host, conn.Port),
+		Password:     conn.Password,
+		DB:           conn.DB,
 		DialTimeout:  defaultDialTimeout,
 		ReadTimeout:  defaultReadTimeout,
 		WriteTimeout: defaultWriteTimeout,
@@ -45,40 +45,27 @@ func (c *Client) cleanup() {
 }
 
 // Connect establishes a connection to Redis
-func (c *Client) Connect(host string, port int, password string, db int) error {
+func (c *Client) Connect(conn *types.Connection) error {
 	c.cleanup()
 
-	client := redis.NewClient(defaultOptions(fmt.Sprintf("%s:%d", host, port), password, db))
-
-	c.mu.Lock()
-	c.host = host
-	c.port = port
-	c.password = password
-	c.db = db
-	c.client = client
-	ctx := c.ctx
-	c.mu.Unlock()
-
-	pingCtx, cancel := context.WithTimeout(ctx, defaultPingTimeout)
-	defer cancel()
-
-	_, err := client.Ping(pingCtx).Result()
-	return err
-}
-
-// ConnectWithTLS establishes a TLS connection to Redis
-func (c *Client) ConnectWithTLS(host string, port int, password string, db int, tlsConfig *tls.Config) error {
-	c.cleanup()
-
-	opts := defaultOptions(fmt.Sprintf("%s:%d", host, port), password, db)
-	opts.TLSConfig = tlsConfig
+	opts := defaultOptions(conn)
+	if conn.UseTLS {
+		if conn.TLSConfig == nil {
+			return fmt.Errorf("TLS requested but TLS configuration is missing")
+		}
+		tslCfg, err := conn.TLSConfig.BuildTLSConfig()
+		if err != nil {
+			return err
+		}
+		opts.TLSConfig = tslCfg
+	}
 	client := redis.NewClient(opts)
 
 	c.mu.Lock()
-	c.host = host
-	c.port = port
-	c.password = password
-	c.db = db
+	c.host = conn.Host
+	c.port = conn.Port
+	c.password = conn.Password
+	c.db = conn.DB
 	c.client = client
 	ctx := c.ctx
 	c.mu.Unlock()
@@ -214,8 +201,8 @@ func (c *Client) SelectDB(db int) error {
 }
 
 // TestConnection tests a connection
-func (c *Client) TestConnection(host string, port int, password string, db int) (time.Duration, error) {
-	testClient := redis.NewClient(defaultOptions(fmt.Sprintf("%s:%d", host, port), password, db))
+func (c *Client) TestConnection(conn *types.Connection) (time.Duration, error) {
+	testClient := redis.NewClient(defaultOptions(conn))
 	defer testClient.Close()
 
 	start := time.Now()

--- a/internal/redis/connection.go
+++ b/internal/redis/connection.go
@@ -23,7 +23,14 @@ const (
 	defaultPingTimeout  = 5 * time.Second
 )
 
-func defaultOptions(conn types.Connection) *redis.Options {
+func defaultOptions(conn types.Connection) (*redis.Options, error) {
+	if conn.Host == "" {
+		return nil, errors.New("host is required")
+	}
+	if conn.Port == 0 {
+		return nil, errors.New("port is required")
+	}
+
 	return &redis.Options{
 		Addr:         fmt.Sprintf("%s:%d", conn.Host, conn.Port),
 		Password:     conn.Password,
@@ -34,7 +41,7 @@ func defaultOptions(conn types.Connection) *redis.Options {
 		PoolSize:     defaultPoolSize,
 		MinIdleConns: defaultMinIdleConns,
 		MaxRetries:   defaultMaxRetries,
-	}
+	}, nil
 }
 
 // cleanup closes existing connections before establishing a new one
@@ -48,7 +55,11 @@ func (c *Client) cleanup() {
 func (c *Client) Connect(conn types.Connection) error {
 	c.cleanup()
 
-	opts := defaultOptions(conn)
+	opts, optErr := defaultOptions(conn)
+	if optErr != nil {
+		return optErr
+	}
+
 	if conn.UseTLS {
 		if conn.TLSConfig == nil {
 			return fmt.Errorf("TLS requested but TLS configuration is missing")
@@ -215,7 +226,11 @@ func (c *Client) SelectDB(db int) error {
 
 // TestConnection tests a connection
 func (c *Client) TestConnection(conn types.Connection) (time.Duration, error) {
-	opts := defaultOptions(conn)
+	opts, optErr := defaultOptions(conn)
+	if optErr != nil {
+		return 0, optErr
+	}
+
 	if conn.UseTLS {
 		if conn.TLSConfig == nil {
 			return 0, fmt.Errorf("TLS requested but TLS configuration is missing")

--- a/internal/redis/connection.go
+++ b/internal/redis/connection.go
@@ -24,6 +24,9 @@ const (
 )
 
 func defaultOptions(conn *types.Connection) *redis.Options {
+	if conn == nil {
+		return nil
+	}
 	return &redis.Options{
 		Addr:         fmt.Sprintf("%s:%d", conn.Host, conn.Port),
 		Password:     conn.Password,
@@ -47,6 +50,10 @@ func (c *Client) cleanup() {
 // Connect establishes a connection to Redis
 func (c *Client) Connect(conn *types.Connection) error {
 	c.cleanup()
+
+	if conn == nil {
+		return fmt.Errorf("connection is nil")
+	}
 
 	opts := defaultOptions(conn)
 	if conn.UseTLS {
@@ -80,6 +87,10 @@ func (c *Client) Connect(conn *types.Connection) error {
 // ConnectCluster establishes a connection to a Redis cluster
 func (c *Client) ConnectCluster(addrs []string, conn *types.Connection) error {
 	c.cleanup()
+
+	if conn == nil {
+		return fmt.Errorf("connection is nil")
+	}
 
 	// Parse first address for display purposes
 	seedHost := "127.0.0.1"
@@ -203,6 +214,9 @@ func (c *Client) SelectDB(db int) error {
 // TestConnection tests a connection
 func (c *Client) TestConnection(conn *types.Connection) (time.Duration, error) {
 	testClient := redis.NewClient(defaultOptions(conn))
+	if conn == nil {
+		return 0, fmt.Errorf("connection is nil")
+	}
 	defer testClient.Close()
 
 	start := time.Now()

--- a/internal/redis/connection.go
+++ b/internal/redis/connection.go
@@ -64,11 +64,11 @@ func (c *Client) Connect(conn types.Connection) error {
 		if conn.TLSConfig == nil {
 			return fmt.Errorf("TLS requested but TLS configuration is missing")
 		}
-		tslCfg, err := conn.TLSConfig.BuildTLSConfig()
+		tlsCfg, err := conn.TLSConfig.BuildTLSConfig()
 		if err != nil {
 			return err
 		}
-		opts.TLSConfig = tslCfg
+		opts.TLSConfig = tlsCfg
 	}
 	client := redis.NewClient(opts)
 
@@ -235,11 +235,11 @@ func (c *Client) TestConnection(conn types.Connection) (time.Duration, error) {
 		if conn.TLSConfig == nil {
 			return 0, fmt.Errorf("TLS requested but TLS configuration is missing")
 		}
-		tslCfg, err := conn.TLSConfig.BuildTLSConfig()
+		tlsCfg, err := conn.TLSConfig.BuildTLSConfig()
 		if err != nil {
 			return 0, err
 		}
-		opts.TLSConfig = tslCfg
+		opts.TLSConfig = tlsCfg
 	}
 	testClient := redis.NewClient(opts)
 	defer testClient.Close()

--- a/internal/redis/connection_test.go
+++ b/internal/redis/connection_test.go
@@ -100,6 +100,22 @@ func TestConnect_CorrectPassword(t *testing.T) {
 	t.Cleanup(func() { _ = client.Disconnect() })
 }
 
+func TestConnect_NilConnection(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	client := NewClient()
+	connErr := client.Connect(nil)
+
+	if connErr == nil {
+		_ = client.Disconnect()
+		t.Error("expected error when connecting with nil connection")
+	}
+}
+
 func TestDisconnect(t *testing.T) {
 	t.Run("disconnect after connect", func(t *testing.T) {
 		mr, err := miniredis.Run()
@@ -228,6 +244,21 @@ func TestReconnectCycle(t *testing.T) {
 	}
 	if got != "reconnectval" {
 		t.Errorf("Get = %q, want %q", got, "reconnectval")
+	}
+}
+
+func TestConnectCluster_NilConnectionError(t *testing.T) {
+	dummyAddrs := []string{"127.0.0.1:7000"}
+	client := NewClient()
+
+	err := client.ConnectCluster(dummyAddrs, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expectedErr := "connection is nil"
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
 	}
 }
 

--- a/internal/redis/connection_test.go
+++ b/internal/redis/connection_test.go
@@ -242,7 +242,7 @@ func TestConnectCluster_UnreachableAddr(t *testing.T) {
 	client := NewClient()
 
 	// Address with default port and host that should not be listening.
-	err := client.ConnectCluster([]string{"127.0.0.1:1"}, "")
+	err := client.ConnectCluster([]string{"127.0.0.1:1"}, &types.Connection{Name: "test", Host: "127.0.0.1", Port: 1, DB: 0, UseCluster: false})
 	if err == nil {
 		_ = client.Disconnect()
 		t.Fatal("ConnectCluster expected error for unreachable addr, got nil")
@@ -269,7 +269,7 @@ func TestConnectCluster_EmptyAddrs(t *testing.T) {
 	client := NewClient()
 
 	// No addresses — should still construct the cluster client and fail on Ping.
-	err := client.ConnectCluster([]string{}, "")
+	err := client.ConnectCluster([]string{}, &types.Connection{Name: "test", Host: "127.0.0.1", Port: 6379, DB: 0, UseCluster: false})
 	if err == nil {
 		_ = client.Disconnect()
 		t.Fatal("ConnectCluster expected error for empty addrs, got nil")
@@ -320,7 +320,7 @@ func TestDisconnect_ClusterCloseBranch(t *testing.T) {
 	client := NewClient()
 
 	// Use unreachable addr — Ping fails but cluster client is still attached.
-	err := client.ConnectCluster([]string{"127.0.0.1:1"}, "")
+	err := client.ConnectCluster([]string{"127.0.0.1:1"}, &types.Connection{Name: "test", Host: "127.0.0.1", Port: 6379, DB: 0, UseCluster: false})
 	if err == nil {
 		_ = client.Disconnect()
 		t.Fatal("ConnectCluster expected error, got nil")
@@ -382,7 +382,7 @@ func TestConnectCluster_DialerSplitHostPortError(t *testing.T) {
 
 	// "no-port" has no colon — net.SplitHostPort returns an error from the
 	// Dialer closure, which exercises the err-return branch.
-	err := client.ConnectCluster([]string{"no-port"}, "")
+	err := client.ConnectCluster([]string{"no-port"}, &types.Connection{Name: "test", Host: "127.0.0.1", Port: 6379, DB: 0, UseCluster: false})
 	if err == nil {
 		t.Fatal("expected error from ConnectCluster with addr lacking a port")
 	}
@@ -403,7 +403,7 @@ func TestSelectDB_SelectError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/connection_test.go
+++ b/internal/redis/connection_test.go
@@ -262,6 +262,59 @@ func TestConnectCluster_NilConnectionError(t *testing.T) {
 	}
 }
 
+func TestConnectCluster_WithTLSErrors(t *testing.T) {
+	t.Run("TLS requested but config is missing", func(t *testing.T) {
+		dummyAddrs := []string{"127.0.0.1:7000"}
+		client := NewClient()
+
+		conn := &types.Connection{
+			Name:   "cluster-tls-missing-config",
+			Host:   "127.0.0.1",
+			Port:   7000,
+			UseTLS: true,
+			// TLSConfig is intentionally nil
+		}
+
+		err := client.ConnectCluster(dummyAddrs, conn)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		expectedErr := "TLS requested but TLS configuration is missing"
+		if err.Error() != expectedErr {
+			t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+		}
+	})
+
+	t.Run("failed to build TLS config", func(t *testing.T) {
+		dummyAddrs := []string{"127.0.0.1:7000"}
+		client := NewClient()
+
+		conn := &types.Connection{
+			Name:   "cluster-tls-build-error",
+			Host:   "127.0.0.1",
+			Port:   7000,
+			UseTLS: true,
+			TLSConfig: &types.TLSConfig{
+				// Providing invalid paths will trigger a file system read error
+				CertFile: "/invalid/path/cert.pem",
+				KeyFile:  "/invalid/path/key.pem",
+			},
+		}
+
+		err := client.ConnectCluster(dummyAddrs, conn)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		// Use substring matching to account for OS-specific underlying errors
+		if !strings.Contains(err.Error(), "failed to build TLS config") &&
+			!strings.Contains(err.Error(), "failed to load TLS key pair") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}
+
 // ---------------------------------------------------------------------------
 // ConnectCluster — exercises the ClusterClient setup and Ping failure path.
 // We pass an unreachable address so the Ping returns an error, but the

--- a/internal/redis/connection_test.go
+++ b/internal/redis/connection_test.go
@@ -48,7 +48,7 @@ func TestConnect(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	if err := client.Connect(mr.Host(), port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect() returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -132,7 +132,7 @@ func TestDisconnect(t *testing.T) {
 		client := NewClient()
 		port, _ := strconv.Atoi(mr.Port())
 
-		if err := client.Connect(mr.Host(), port, "", 0); err != nil {
+		if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 			t.Fatalf("Connect() returned error: %v", err)
 		}
 
@@ -204,7 +204,7 @@ func TestCleanup(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	if err := client.Connect(mr.Host(), port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect() returned error: %v", err)
 	}
 
@@ -226,7 +226,7 @@ func TestReconnectCycle(t *testing.T) {
 	port, _ := strconv.Atoi(mr.Port())
 
 	// First connect
-	if err := client.Connect(mr.Host(), port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("first Connect() returned error: %v", err)
 	}
 
@@ -236,7 +236,7 @@ func TestReconnectCycle(t *testing.T) {
 	}
 
 	// Reconnect
-	if err := client.Connect(mr.Host(), port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("second Connect() returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })

--- a/internal/redis/connection_test.go
+++ b/internal/redis/connection_test.go
@@ -1,10 +1,13 @@
 package redis
 
 import (
+	"crypto/tls"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/davidbudnick/redis-tui/internal/testutil"
 	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
@@ -114,6 +117,94 @@ func TestConnect_NilConnection(t *testing.T) {
 		_ = client.Disconnect()
 		t.Error("expected error when connecting with nil connection")
 	}
+}
+
+func TestConnect_WithTLS(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		serverCert := testutil.GenerateEphemeralCert(t)
+
+		serverTLSConfig := &tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+		}
+
+		mr, err := miniredis.RunTLS(serverTLSConfig)
+		if err != nil {
+			t.Fatalf("failed to start miniredis with TLS: %v", err)
+		}
+		t.Cleanup(mr.Close)
+
+		client := NewClient()
+		port, _ := strconv.Atoi(mr.Port())
+
+		conn := &types.Connection{
+			Name:   "tls-test",
+			Host:   mr.Host(),
+			Port:   port,
+			UseTLS: true,
+			TLSConfig: &types.TLSConfig{
+				InsecureSkipVerify: true,
+			},
+		}
+		if err := client.Connect(conn); err != nil {
+			t.Fatalf("Connect() with TLS returned error: %v", err)
+		}
+		t.Cleanup(func() { _ = client.Disconnect() })
+
+		// Verify the client is usable by setting and getting a key
+		mr.Set("tlskey", "tlsval")
+		got, err := client.client.Get(client.ctx, "tlskey").Result()
+		if err != nil {
+			t.Fatalf("Get after TLS Connect failed: %v", err)
+		}
+		if got != "tlsval" {
+			t.Errorf("Get = %q, want %q", got, "tlsval")
+		}
+	})
+	t.Run("TLS requested but config is missing", func(t *testing.T) {
+		client := NewClient()
+
+		conn := &types.Connection{
+			Name:   "tls-missing-config",
+			Host:   "localhost",
+			Port:   6379,
+			UseTLS: true,
+			// TLSConfig is intentionally left nil
+		}
+
+		err := client.Connect(conn)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		expectedErr := "TLS requested but TLS configuration is missing"
+		if err.Error() != expectedErr {
+			t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+		}
+	})
+	t.Run("failed to build TLS config", func(t *testing.T) {
+		client := NewClient()
+
+		conn := &types.Connection{
+			Name:   "tls-build-error",
+			Host:   "localhost",
+			Port:   6379,
+			UseTLS: true,
+			TLSConfig: &types.TLSConfig{
+				CertFile: "/path/to/nowhere/cert.pem",
+				KeyFile:  "/path/to/nowhere/key.pem",
+			},
+		}
+
+		err := client.Connect(conn)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "failed to build TLS config") &&
+			!strings.Contains(err.Error(), "failed to load TLS key pair") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
 }
 
 func TestDisconnect(t *testing.T) {

--- a/internal/redis/connection_test.go
+++ b/internal/redis/connection_test.go
@@ -64,27 +64,6 @@ func TestConnect(t *testing.T) {
 	}
 }
 
-func TestConnectWithTLS_NonTLSServer(t *testing.T) {
-	// Connecting with TLS to a non-TLS miniredis should fail
-	mr, err := miniredis.Run()
-	if err != nil {
-		t.Fatalf("failed to start miniredis: %v", err)
-	}
-	t.Cleanup(mr.Close)
-
-	client := NewClient()
-	port, _ := strconv.Atoi(mr.Port())
-
-	tlsCfg := &types.TLSConfig{InsecureSkipVerify: true}
-	goTLS, _ := tlsCfg.BuildTLSConfig()
-
-	err = client.ConnectWithTLS(mr.Host(), port, "", 0, goTLS)
-	if err == nil {
-		_ = client.Disconnect()
-		t.Fatal("expected error when connecting with TLS to non-TLS server")
-	}
-}
-
 func TestConnect_WrongPassword(t *testing.T) {
 	mr, err := miniredis.Run()
 	if err != nil {
@@ -96,7 +75,7 @@ func TestConnect_WrongPassword(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	err = client.Connect(mr.Host(), port, "wrong-password", 0)
+	err = client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "wrong-password", DB: 0, UseCluster: false})
 	if err == nil {
 		_ = client.Disconnect()
 		t.Fatal("expected error when connecting with wrong password")
@@ -114,7 +93,7 @@ func TestConnect_CorrectPassword(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	err = client.Connect(mr.Host(), port, "correct-password", 0)
+	err = client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "correct-password", DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("Connect() with correct password returned error: %v", err)
 	}

--- a/internal/redis/connection_test.go
+++ b/internal/redis/connection_test.go
@@ -51,7 +51,7 @@ func TestConnect(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect() returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -78,7 +78,7 @@ func TestConnect_WrongPassword(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	err = client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "wrong-password", DB: 0, UseCluster: false})
+	err = client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "wrong-password", DB: 0, UseCluster: false})
 	if err == nil {
 		_ = client.Disconnect()
 		t.Fatal("expected error when connecting with wrong password")
@@ -96,27 +96,11 @@ func TestConnect_CorrectPassword(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	err = client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "correct-password", DB: 0, UseCluster: false})
+	err = client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "correct-password", DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("Connect() with correct password returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
-}
-
-func TestConnect_NilConnection(t *testing.T) {
-	mr, err := miniredis.Run()
-	if err != nil {
-		t.Fatalf("failed to start miniredis: %v", err)
-	}
-	t.Cleanup(mr.Close)
-
-	client := NewClient()
-	connErr := client.Connect(nil)
-
-	if connErr == nil {
-		_ = client.Disconnect()
-		t.Error("expected error when connecting with nil connection")
-	}
 }
 
 func TestConnect_WithTLS(t *testing.T) {
@@ -136,7 +120,7 @@ func TestConnect_WithTLS(t *testing.T) {
 		client := NewClient()
 		port, _ := strconv.Atoi(mr.Port())
 
-		conn := &types.Connection{
+		conn := types.Connection{
 			Name:   "tls-test",
 			Host:   mr.Host(),
 			Port:   port,
@@ -163,7 +147,7 @@ func TestConnect_WithTLS(t *testing.T) {
 	t.Run("TLS requested but config is missing", func(t *testing.T) {
 		client := NewClient()
 
-		conn := &types.Connection{
+		conn := types.Connection{
 			Name:   "tls-missing-config",
 			Host:   "localhost",
 			Port:   6379,
@@ -184,7 +168,7 @@ func TestConnect_WithTLS(t *testing.T) {
 	t.Run("failed to build TLS config", func(t *testing.T) {
 		client := NewClient()
 
-		conn := &types.Connection{
+		conn := types.Connection{
 			Name:   "tls-build-error",
 			Host:   "localhost",
 			Port:   6379,
@@ -218,7 +202,7 @@ func TestDisconnect(t *testing.T) {
 		client := NewClient()
 		port, _ := strconv.Atoi(mr.Port())
 
-		if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+		if err := client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 			t.Fatalf("Connect() returned error: %v", err)
 		}
 
@@ -290,7 +274,7 @@ func TestCleanup(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect() returned error: %v", err)
 	}
 
@@ -312,7 +296,7 @@ func TestReconnectCycle(t *testing.T) {
 	port, _ := strconv.Atoi(mr.Port())
 
 	// First connect
-	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("first Connect() returned error: %v", err)
 	}
 
@@ -322,7 +306,7 @@ func TestReconnectCycle(t *testing.T) {
 	}
 
 	// Reconnect
-	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("second Connect() returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -338,27 +322,12 @@ func TestReconnectCycle(t *testing.T) {
 	}
 }
 
-func TestConnectCluster_NilConnectionError(t *testing.T) {
-	dummyAddrs := []string{"127.0.0.1:7000"}
-	client := NewClient()
-
-	err := client.ConnectCluster(dummyAddrs, nil)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
-	expectedErr := "connection is nil"
-	if err.Error() != expectedErr {
-		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
-	}
-}
-
 func TestConnectCluster_WithTLSErrors(t *testing.T) {
 	t.Run("TLS requested but config is missing", func(t *testing.T) {
 		dummyAddrs := []string{"127.0.0.1:7000"}
 		client := NewClient()
 
-		conn := &types.Connection{
+		conn := types.Connection{
 			Name:   "cluster-tls-missing-config",
 			Host:   "127.0.0.1",
 			Port:   7000,
@@ -381,7 +350,7 @@ func TestConnectCluster_WithTLSErrors(t *testing.T) {
 		dummyAddrs := []string{"127.0.0.1:7000"}
 		client := NewClient()
 
-		conn := &types.Connection{
+		conn := types.Connection{
 			Name:   "cluster-tls-build-error",
 			Host:   "127.0.0.1",
 			Port:   7000,
@@ -417,7 +386,7 @@ func TestConnectCluster_UnreachableAddr(t *testing.T) {
 	client := NewClient()
 
 	// Address with default port and host that should not be listening.
-	err := client.ConnectCluster([]string{"127.0.0.1:1"}, &types.Connection{Name: "test", Host: "127.0.0.1", Port: 1, DB: 0, UseCluster: false})
+	err := client.ConnectCluster([]string{"127.0.0.1:1"}, types.Connection{Name: "test", Host: "127.0.0.1", Port: 1, DB: 0, UseCluster: false})
 	if err == nil {
 		_ = client.Disconnect()
 		t.Fatal("ConnectCluster expected error for unreachable addr, got nil")
@@ -444,7 +413,7 @@ func TestConnectCluster_EmptyAddrs(t *testing.T) {
 	client := NewClient()
 
 	// No addresses — should still construct the cluster client and fail on Ping.
-	err := client.ConnectCluster([]string{}, &types.Connection{Name: "test", Host: "127.0.0.1", Port: 6379, DB: 0, UseCluster: false})
+	err := client.ConnectCluster([]string{}, types.Connection{Name: "test", Host: "127.0.0.1", Port: 6379, DB: 0, UseCluster: false})
 	if err == nil {
 		_ = client.Disconnect()
 		t.Fatal("ConnectCluster expected error for empty addrs, got nil")
@@ -495,7 +464,7 @@ func TestDisconnect_ClusterCloseBranch(t *testing.T) {
 	client := NewClient()
 
 	// Use unreachable addr — Ping fails but cluster client is still attached.
-	err := client.ConnectCluster([]string{"127.0.0.1:1"}, &types.Connection{Name: "test", Host: "127.0.0.1", Port: 6379, DB: 0, UseCluster: false})
+	err := client.ConnectCluster([]string{"127.0.0.1:1"}, types.Connection{Name: "test", Host: "127.0.0.1", Port: 6379, DB: 0, UseCluster: false})
 	if err == nil {
 		_ = client.Disconnect()
 		t.Fatal("ConnectCluster expected error, got nil")
@@ -557,7 +526,7 @@ func TestConnectCluster_DialerSplitHostPortError(t *testing.T) {
 
 	// "no-port" has no colon — net.SplitHostPort returns an error from the
 	// Dialer closure, which exercises the err-return branch.
-	err := client.ConnectCluster([]string{"no-port"}, &types.Connection{Name: "test", Host: "127.0.0.1", Port: 6379, DB: 0, UseCluster: false})
+	err := client.ConnectCluster([]string{"no-port"}, types.Connection{Name: "test", Host: "127.0.0.1", Port: 6379, DB: 0, UseCluster: false})
 	if err == nil {
 		t.Fatal("expected error from ConnectCluster with addr lacking a port")
 	}
@@ -578,7 +547,7 @@ func TestSelectDB_SelectError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/connection_test.go
+++ b/internal/redis/connection_test.go
@@ -85,6 +85,40 @@ func TestConnect_WrongPassword(t *testing.T) {
 	}
 }
 
+func TestConnect_EmptyHostError(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	client := NewClient()
+	port, _ := strconv.Atoi(mr.Port())
+
+	err = client.Connect(types.Connection{Name: "test", Host: "", Port: port, Password: "wrong-password", DB: 0, UseCluster: false})
+	if err == nil {
+		_ = client.Disconnect()
+		t.Fatal("expected error when connecting with empty host")
+	}
+}
+
+func TestConnect_EmptyPortError(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	client := NewClient()
+	port := 0
+
+	err = client.Connect(types.Connection{Name: "", Host: mr.Host(), Port: port, Password: "wrong-password", DB: 0, UseCluster: false})
+	if err == nil {
+		_ = client.Disconnect()
+		t.Fatal("expected error when connecting with empty port")
+	}
+}
+
 func TestConnect_CorrectPassword(t *testing.T) {
 	mr, err := miniredis.Run()
 	if err != nil {

--- a/internal/redis/enumeration_test.go
+++ b/internal/redis/enumeration_test.go
@@ -552,7 +552,7 @@ func TestGetTotalKeys_Error(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -577,7 +577,7 @@ func TestScanKeys_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -606,7 +606,7 @@ func TestScanKeys_PipeExecError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -666,7 +666,7 @@ func TestScanKeysWithRegex_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -690,7 +690,7 @@ func TestFuzzySearchKeys_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -714,7 +714,7 @@ func TestSearchByValue_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -749,7 +749,7 @@ func TestSearchByValue_ReJSONAndDefault(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -788,7 +788,7 @@ func TestGetKeyPrefixes_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -853,7 +853,7 @@ func TestDetectStringSubtypes_GetError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -894,7 +894,7 @@ func TestDetectZSetSubtypes_ZRangeError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/enumeration_test.go
+++ b/internal/redis/enumeration_test.go
@@ -552,7 +552,7 @@ func TestGetTotalKeys_Error(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -577,7 +577,7 @@ func TestScanKeys_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -606,7 +606,7 @@ func TestScanKeys_PipeExecError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -666,7 +666,7 @@ func TestScanKeysWithRegex_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -690,7 +690,7 @@ func TestFuzzySearchKeys_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -714,7 +714,7 @@ func TestSearchByValue_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -749,7 +749,7 @@ func TestSearchByValue_ReJSONAndDefault(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -788,7 +788,7 @@ func TestGetKeyPrefixes_ScanError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -853,7 +853,7 @@ func TestDetectStringSubtypes_GetError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -894,7 +894,7 @@ func TestDetectZSetSubtypes_ZRangeError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/io_test.go
+++ b/internal/redis/io_test.go
@@ -609,7 +609,7 @@ func TestExportKeys_ScanAllError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -669,7 +669,7 @@ func TestExportKeys_AllValueFetchErrors(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -705,7 +705,7 @@ func TestExportKeys_UnknownType_DefaultContinue(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -745,7 +745,7 @@ func TestExportKeys_ReJSON_TextError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -782,7 +782,7 @@ func TestExportKeys_ReJSON_Success(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -1047,7 +1047,7 @@ func TestCompareKeys_TypeExecError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/io_test.go
+++ b/internal/redis/io_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
 // ---------------------------------------------------------------------------
@@ -607,7 +609,7 @@ func TestExportKeys_ScanAllError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -667,7 +669,7 @@ func TestExportKeys_AllValueFetchErrors(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -703,7 +705,7 @@ func TestExportKeys_UnknownType_DefaultContinue(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -743,7 +745,7 @@ func TestExportKeys_ReJSON_TextError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -780,7 +782,7 @@ func TestExportKeys_ReJSON_Success(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -1045,7 +1047,7 @@ func TestCompareKeys_TypeExecError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/operations_test.go
+++ b/internal/redis/operations_test.go
@@ -741,7 +741,7 @@ func TestGetValue_HyperLogLog_PFCountSuccess(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -773,7 +773,7 @@ func TestGetValue_TypeError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -800,7 +800,7 @@ func gvFakeClient(t *testing.T, keyType string, valueCmd string) *Client {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -863,7 +863,7 @@ func TestGetValue_ReJSON_Success(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -894,7 +894,7 @@ func TestGetValue_ReJSON_Error(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -918,7 +918,7 @@ func TestBulkDelete_ScanAllError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -944,7 +944,7 @@ func TestBulkDelete_DelError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -968,7 +968,7 @@ func TestBatchSetTTL_ScanAllError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/operations_test.go
+++ b/internal/redis/operations_test.go
@@ -741,7 +741,7 @@ func TestGetValue_HyperLogLog_PFCountSuccess(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -773,7 +773,7 @@ func TestGetValue_TypeError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -800,7 +800,7 @@ func gvFakeClient(t *testing.T, keyType string, valueCmd string) *Client {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -863,7 +863,7 @@ func TestGetValue_ReJSON_Success(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -894,7 +894,7 @@ func TestGetValue_ReJSON_Error(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -918,7 +918,7 @@ func TestBulkDelete_ScanAllError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -944,7 +944,7 @@ func TestBulkDelete_DelError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -968,7 +968,7 @@ func TestBatchSetTTL_ScanAllError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/server_mock_test.go
+++ b/internal/redis/server_mock_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davidbudnick/redis-tui/internal/types"
 	goredis "github.com/redis/go-redis/v9"
 )
 
@@ -272,7 +273,7 @@ func TestGetServerInfo_FullInfoParsing(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(host, port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -341,7 +342,7 @@ func TestGetMemoryStats_FullInfoParsing(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(host, port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -400,7 +401,7 @@ func TestGetLiveMetrics_FullInfoParsing(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(host, port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -466,7 +467,7 @@ func TestClientList_FullParsing(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(host, port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -521,7 +522,7 @@ func TestClusterInfo_FakeReply(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(host, port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -549,7 +550,7 @@ func TestClusterNodes_FakeReply(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(host, port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -776,7 +777,7 @@ func TestSlowLogGet_NonEmpty(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(host, port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })

--- a/internal/redis/server_mock_test.go
+++ b/internal/redis/server_mock_test.go
@@ -273,7 +273,7 @@ func TestGetServerInfo_FullInfoParsing(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -342,7 +342,7 @@ func TestGetMemoryStats_FullInfoParsing(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -401,7 +401,7 @@ func TestGetLiveMetrics_FullInfoParsing(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -467,7 +467,7 @@ func TestClientList_FullParsing(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -522,7 +522,7 @@ func TestClusterInfo_FakeReply(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -550,7 +550,7 @@ func TestClusterNodes_FakeReply(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -777,7 +777,7 @@ func TestSlowLogGet_NonEmpty(t *testing.T) {
 
 	host, port := srv.addr()
 	client := NewClient()
-	if err := client.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect to fake server: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })

--- a/internal/redis/server_test.go
+++ b/internal/redis/server_test.go
@@ -279,6 +279,23 @@ func TestTestConnection(t *testing.T) {
 			t.Fatal("TestConnection() expected error for unreachable host, got nil")
 		}
 	})
+
+	t.Run("nil conn", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		if err != nil {
+			t.Fatalf("failed to start miniredis: %v", err)
+		}
+		t.Cleanup(mr.Close)
+
+		client := NewClient()
+		_, connErr := client.TestConnection(nil)
+
+		if connErr == nil {
+			_ = client.Disconnect()
+			t.Error("expected error when connecting with nil connection")
+		}
+	})
+
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/redis/server_test.go
+++ b/internal/redis/server_test.go
@@ -243,7 +243,7 @@ func TestTestConnection(t *testing.T) {
 			t.Fatalf("failed to parse port: %v", err)
 		}
 
-		latency, err := client.TestConnection(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false})
+		latency, err := client.TestConnection(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false})
 		if err != nil {
 			t.Fatalf("TestConnection() error = %v", err)
 		}
@@ -256,7 +256,7 @@ func TestTestConnection(t *testing.T) {
 		client, _ := setupTestClient(t)
 
 		// Use a port that is almost certainly not listening
-		_, err := client.TestConnection(&types.Connection{Name: "test", Host: "127.0.0.1", Port: 1, Password: "", DB: 0, UseCluster: false})
+		_, err := client.TestConnection(types.Connection{Name: "test", Host: "127.0.0.1", Port: 1, Password: "", DB: 0, UseCluster: false})
 		if err == nil {
 			t.Fatal("TestConnection() expected error for wrong port, got nil")
 		}
@@ -272,30 +272,14 @@ func TestTestConnection(t *testing.T) {
 
 		c := NewClient()
 		port, _ := strconv.Atoi(mr.Port())
-		if err := c.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+		if err := c.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 			t.Fatalf("Connect() error = %v", err)
 		}
 		t.Cleanup(func() { _ = c.Disconnect() })
 
-		_, err = c.TestConnection(&types.Connection{Name: "test", Host: "192.0.2.1", Port: 6379, Password: "", DB: 0, UseCluster: false})
+		_, err = c.TestConnection(types.Connection{Name: "test", Host: "192.0.2.1", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		if err == nil {
 			t.Fatal("TestConnection() expected error for unreachable host, got nil")
-		}
-	})
-
-	t.Run("nil conn", func(t *testing.T) {
-		mr, err := miniredis.Run()
-		if err != nil {
-			t.Fatalf("failed to start miniredis: %v", err)
-		}
-		t.Cleanup(mr.Close)
-
-		client := NewClient()
-		_, connErr := client.TestConnection(nil)
-
-		if connErr == nil {
-			_ = client.Disconnect()
-			t.Error("expected error when connecting with nil connection")
 		}
 	})
 
@@ -315,7 +299,7 @@ func TestTestConnection(t *testing.T) {
 		client := NewClient()
 		port, _ := strconv.Atoi(mr.Port())
 
-		conn := &types.Connection{
+		conn := types.Connection{
 			Name:   "tls-test",
 			Host:   mr.Host(),
 			Port:   port,
@@ -337,7 +321,7 @@ func TestTestConnection(t *testing.T) {
 	t.Run("TLS requested but config is missing", func(t *testing.T) {
 		client := NewClient()
 
-		conn := &types.Connection{
+		conn := types.Connection{
 			Name:   "tls-missing-config",
 			Host:   "localhost",
 			Port:   6379,
@@ -360,7 +344,7 @@ func TestTestConnection(t *testing.T) {
 	})
 	client := NewClient()
 
-	conn := &types.Connection{
+	conn := types.Connection{
 		Name:   "tls-build-error",
 		Host:   "localhost",
 		Port:   6379,
@@ -590,7 +574,7 @@ func TestGetServerInfo_InfoError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -612,7 +596,7 @@ func TestGetServerInfo_MalformedLine(t *testing.T) {
 
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -650,7 +634,7 @@ func TestGetTopKeysByMemory_MemErrorContinues(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -673,7 +657,7 @@ func TestClientList_MalformedField(t *testing.T) {
 
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -704,7 +688,7 @@ func TestClusterNodes_Error(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -755,7 +739,7 @@ func TestGetLiveMetrics_MalformedLine(t *testing.T) {
 
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/server_test.go
+++ b/internal/redis/server_test.go
@@ -283,6 +283,48 @@ func TestTestConnection(t *testing.T) {
 		}
 	})
 
+	t.Run("empty host returns error", func(t *testing.T) {
+		// Start a separate miniredis so we have a valid client context
+		mr, err := miniredis.Run()
+		if err != nil {
+			t.Fatalf("failed to start miniredis: %v", err)
+		}
+		t.Cleanup(mr.Close)
+
+		c := NewClient()
+		port, _ := strconv.Atoi(mr.Port())
+		if err := c.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+			t.Fatalf("Connect() error = %v", err)
+		}
+		t.Cleanup(func() { _ = c.Disconnect() })
+
+		_, err = c.TestConnection(types.Connection{Name: "test", Host: "", Port: 6379, Password: "", DB: 0, UseCluster: false})
+		if err == nil {
+			t.Fatal("TestConnection() expected error for empty host, got nil")
+		}
+	})
+
+	t.Run("empty port returns error", func(t *testing.T) {
+		// Start a separate miniredis so we have a valid client context
+		mr, err := miniredis.Run()
+		if err != nil {
+			t.Fatalf("failed to start miniredis: %v", err)
+		}
+		t.Cleanup(mr.Close)
+
+		c := NewClient()
+		port, _ := strconv.Atoi(mr.Port())
+		if err := c.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+			t.Fatalf("Connect() error = %v", err)
+		}
+		t.Cleanup(func() { _ = c.Disconnect() })
+
+		_, err = c.TestConnection(types.Connection{Name: "test", Host: "192.168.0.1", Port: 0, Password: "", DB: 0, UseCluster: false})
+		if err == nil {
+			t.Fatal("TestConnection() expected error for empty port, got nil")
+		}
+	})
+
 	t.Run("successful connection with TLS returns latency", func(t *testing.T) {
 		serverCert := testutil.GenerateEphemeralCert(t)
 

--- a/internal/redis/server_test.go
+++ b/internal/redis/server_test.go
@@ -1,12 +1,15 @@
 package redis
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/davidbudnick/redis-tui/internal/testutil"
 	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
@@ -296,6 +299,87 @@ func TestTestConnection(t *testing.T) {
 		}
 	})
 
+	t.Run("successful connection with TLS returns latency", func(t *testing.T) {
+		serverCert := testutil.GenerateEphemeralCert(t)
+
+		serverTLSConfig := &tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+		}
+
+		mr, err := miniredis.RunTLS(serverTLSConfig)
+		if err != nil {
+			t.Fatalf("failed to start miniredis with TLS: %v", err)
+		}
+		t.Cleanup(mr.Close)
+
+		client := NewClient()
+		port, _ := strconv.Atoi(mr.Port())
+
+		conn := &types.Connection{
+			Name:   "tls-test",
+			Host:   mr.Host(),
+			Port:   port,
+			UseTLS: true,
+			TLSConfig: &types.TLSConfig{
+				InsecureSkipVerify: true,
+			},
+		}
+		latency, err := client.TestConnection(conn)
+		if err != nil {
+			t.Fatalf("Connect() with TLS returned error: %v", err)
+		}
+		t.Cleanup(func() { _ = client.Disconnect() })
+		if latency <= 0 {
+			t.Errorf("TestConnection() latency = %v, want > 0", latency)
+		}
+	})
+
+	t.Run("TLS requested but config is missing", func(t *testing.T) {
+		client := NewClient()
+
+		conn := &types.Connection{
+			Name:   "tls-missing-config",
+			Host:   "localhost",
+			Port:   6379,
+			UseTLS: true,
+			// TLSConfig is intentionally left nil
+		}
+
+		_, err := client.TestConnection(conn)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		expectedErr := "TLS requested but TLS configuration is missing"
+		if err.Error() != expectedErr {
+			t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+		}
+	})
+
+	t.Run("failed to build TLS config", func(t *testing.T) {
+	})
+	client := NewClient()
+
+	conn := &types.Connection{
+		Name:   "tls-build-error",
+		Host:   "localhost",
+		Port:   6379,
+		UseTLS: true,
+		TLSConfig: &types.TLSConfig{
+			CertFile: "/path/to/nowhere/cert.pem",
+			KeyFile:  "/path/to/nowhere/key.pem",
+		},
+	}
+
+	_, err := client.TestConnection(conn)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to build TLS config") &&
+		!strings.Contains(err.Error(), "failed to load TLS key pair") {
+		t.Errorf("unexpected error message: %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/redis/server_test.go
+++ b/internal/redis/server_test.go
@@ -489,7 +489,7 @@ func TestGetServerInfo_InfoError(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -511,7 +511,7 @@ func TestGetServerInfo_MalformedLine(t *testing.T) {
 
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -549,7 +549,7 @@ func TestGetTopKeysByMemory_MemErrorContinues(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -572,7 +572,7 @@ func TestClientList_MalformedField(t *testing.T) {
 
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -603,7 +603,7 @@ func TestClusterNodes_Error(t *testing.T) {
 	})
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })
@@ -654,7 +654,7 @@ func TestGetLiveMetrics_MalformedLine(t *testing.T) {
 
 	host, port := srv.addr()
 	c := NewClient()
-	if err := c.Connect(host, port, "", 0); err != nil {
+	if err := c.Connect(&types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Disconnect() })

--- a/internal/redis/server_test.go
+++ b/internal/redis/server_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
 func TestParseClusterNodes(t *testing.T) {
@@ -239,7 +240,7 @@ func TestTestConnection(t *testing.T) {
 			t.Fatalf("failed to parse port: %v", err)
 		}
 
-		latency, err := client.TestConnection(mr.Host(), port, "", 0)
+		latency, err := client.TestConnection(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false})
 		if err != nil {
 			t.Fatalf("TestConnection() error = %v", err)
 		}
@@ -252,7 +253,7 @@ func TestTestConnection(t *testing.T) {
 		client, _ := setupTestClient(t)
 
 		// Use a port that is almost certainly not listening
-		_, err := client.TestConnection("127.0.0.1", 1, "", 0)
+		_, err := client.TestConnection(&types.Connection{Name: "test", Host: "127.0.0.1", Port: 1, Password: "", DB: 0, UseCluster: false})
 		if err == nil {
 			t.Fatal("TestConnection() expected error for wrong port, got nil")
 		}
@@ -268,12 +269,12 @@ func TestTestConnection(t *testing.T) {
 
 		c := NewClient()
 		port, _ := strconv.Atoi(mr.Port())
-		if err := c.Connect(mr.Host(), port, "", 0); err != nil {
+		if err := c.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 			t.Fatalf("Connect() error = %v", err)
 		}
 		t.Cleanup(func() { _ = c.Disconnect() })
 
-		_, err = c.TestConnection("192.0.2.1", 6379, "", 0)
+		_, err = c.TestConnection(&types.Connection{Name: "test", Host: "192.0.2.1", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		if err == nil {
 			t.Fatal("TestConnection() expected error for unreachable host, got nil")
 		}

--- a/internal/redis/testhelper_test.go
+++ b/internal/redis/testhelper_test.go
@@ -18,7 +18,7 @@ func setupTestClient(t *testing.T) (*Client, *miniredis.Miniredis) {
 
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
-	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("failed to connect: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })

--- a/internal/redis/testhelper_test.go
+++ b/internal/redis/testhelper_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
 func setupTestClient(t *testing.T) (*Client, *miniredis.Miniredis) {
@@ -17,7 +18,7 @@ func setupTestClient(t *testing.T) (*Client, *miniredis.Miniredis) {
 
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
-	if err := client.Connect(mr.Host(), port, "", 0); err != nil {
+	if err := client.Connect(&types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("failed to connect: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -2,7 +2,6 @@
 package service
 
 import (
-	"crypto/tls"
 	"time"
 
 	"github.com/davidbudnick/redis-tui/internal/types"
@@ -13,8 +12,8 @@ import (
 type ConfigService interface {
 	// Connection management
 	ListConnections() ([]types.Connection, error)
-	AddConnection(name, host string, port int, password string, db int, useCluster bool) (types.Connection, error)
-	UpdateConnection(id int64, name, host string, port int, password string, db int, useCluster bool) (types.Connection, error)
+	AddConnection(conn types.Connection) (types.Connection, error)
+	UpdateConnection(conn types.Connection) (types.Connection, error)
 	DeleteConnection(id int64) error
 
 	// Favorites management
@@ -59,12 +58,11 @@ type ConfigService interface {
 // RedisService defines the interface for Redis operations.
 type RedisService interface {
 	// Connection management
-	Connect(host string, port int, password string, db int) error
-	ConnectWithTLS(host string, port int, password string, db int, tlsConfig *tls.Config) error
+	Connect(conn *types.Connection) error
 	ConnectCluster(addrs []string, password string) error
 	Disconnect() error
 	IsCluster() bool
-	TestConnection(host string, port int, password string, db int) (time.Duration, error)
+	TestConnection(conn *types.Connection) (time.Duration, error)
 
 	// Key operations
 	GetTotalKeys() int64

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -58,11 +58,11 @@ type ConfigService interface {
 // RedisService defines the interface for Redis operations.
 type RedisService interface {
 	// Connection management
-	Connect(conn *types.Connection) error
-	ConnectCluster(addrs []string, conn *types.Connection) error
+	Connect(conn types.Connection) error
+	ConnectCluster(addrs []string, conn types.Connection) error
 	Disconnect() error
 	IsCluster() bool
-	TestConnection(conn *types.Connection) (time.Duration, error)
+	TestConnection(conn types.Connection) (time.Duration, error)
 
 	// Key operations
 	GetTotalKeys() int64

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -59,7 +59,7 @@ type ConfigService interface {
 type RedisService interface {
 	// Connection management
 	Connect(conn *types.Connection) error
-	ConnectCluster(addrs []string, password string) error
+	ConnectCluster(addrs []string, conn *types.Connection) error
 	Disconnect() error
 	IsCluster() bool
 	TestConnection(conn *types.Connection) (time.Duration, error)

--- a/internal/testutil/mock_config.go
+++ b/internal/testutil/mock_config.go
@@ -57,13 +57,15 @@ func (m *MockConfigClient) Close() error { return m.CloseError }
 func (m *MockConfigClient) ListConnections() ([]types.Connection, error) {
 	return m.ListConnectionsResult, m.ListConnectionsError
 }
-func (m *MockConfigClient) AddConnection(_, _ string, _ int, _ string, _ int, _ bool) (types.Connection, error) {
+
+func (m *MockConfigClient) AddConnection(_ types.Connection) (types.Connection, error) {
 	return m.AddConnectionResult, m.AddConnectionError
 }
-func (m *MockConfigClient) UpdateConnection(_ int64, _, _ string, _ int, _ string, _ int, _ bool) (types.Connection, error) {
+
+func (m *MockConfigClient) UpdateConnection(_ types.Connection) (types.Connection, error) {
 	return m.UpdateConnectionResult, m.UpdateConnectionError
 }
-func (m *MockConfigClient) DeleteConnection(_ int64) error                          { return m.DeleteConnectionError }
+func (m *MockConfigClient) DeleteConnection(_ int64) error { return m.DeleteConnectionError }
 func (m *MockConfigClient) AddFavorite(_ int64, _, _ string) (types.Favorite, error) {
 	return m.AddFavoriteResult, m.AddFavoriteError
 }

--- a/internal/testutil/mock_config_test.go
+++ b/internal/testutil/mock_config_test.go
@@ -69,7 +69,7 @@ func TestMockConfigClient_AddConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := NewMockConfigClient()
 		m.AddConnectionResult = types.Connection{ID: 1, Name: "new"}
-		got, err := m.AddConnection("new", "localhost", 6379, "", 0, false)
+		got, err := m.AddConnection(types.Connection{Name: "new", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		AssertNoError(t, err, "AddConnection")
 		AssertEqual(t, got.Name, "new", "connection name")
 	})
@@ -77,7 +77,7 @@ func TestMockConfigClient_AddConnection(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		m := NewMockConfigClient()
 		m.AddConnectionError = errConfig
-		_, err := m.AddConnection("new", "localhost", 6379, "", 0, false)
+		_, err := m.AddConnection(types.Connection{Name: "new", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		if !errors.Is(err, errConfig) {
 			t.Errorf("expected errConfig, got %v", err)
 		}
@@ -88,7 +88,8 @@ func TestMockConfigClient_UpdateConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := NewMockConfigClient()
 		m.UpdateConnectionResult = types.Connection{ID: 1, Name: "updated"}
-		got, err := m.UpdateConnection(1, "updated", "localhost", 6379, "", 0, false)
+		toUpdateConn := types.Connection{ID: 1, Name: "updated", Host: "localhost", Port: 6379, DB: 0, UseCluster: false}
+		got, err := m.UpdateConnection(toUpdateConn)
 		AssertNoError(t, err, "UpdateConnection")
 		AssertEqual(t, got.Name, "updated", "connection name")
 	})
@@ -96,7 +97,7 @@ func TestMockConfigClient_UpdateConnection(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		m := NewMockConfigClient()
 		m.UpdateConnectionError = errConfig
-		_, err := m.UpdateConnection(1, "updated", "localhost", 6379, "", 0, false)
+		_, err := m.UpdateConnection(types.Connection{ID: 1, Name: "updated", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		if !errors.Is(err, errConfig) {
 			t.Errorf("expected errConfig, got %v", err)
 		}

--- a/internal/testutil/mock_redis.go
+++ b/internal/testutil/mock_redis.go
@@ -36,7 +36,7 @@ func NewMockRedisClient() *MockRedisClient {
 }
 
 // Connect simulates connecting to Redis.
-func (m *MockRedisClient) Connect(host string, port int, password string, db int) error {
+func (m *MockRedisClient) Connect(conn *types.Connection) error {
 	if m.ConnectError != nil {
 		return m.ConnectError
 	}

--- a/internal/testutil/mock_redis.go
+++ b/internal/testutil/mock_redis.go
@@ -36,7 +36,7 @@ func NewMockRedisClient() *MockRedisClient {
 }
 
 // Connect simulates connecting to Redis.
-func (m *MockRedisClient) Connect(conn *types.Connection) error {
+func (m *MockRedisClient) Connect(conn types.Connection) error {
 	if m.ConnectError != nil {
 		return m.ConnectError
 	}

--- a/internal/testutil/mock_redis_full.go
+++ b/internal/testutil/mock_redis_full.go
@@ -138,7 +138,7 @@ func (m *FullMockRedisClient) Connect(conn *types.Connection) error {
 	return m.MockRedisClient.Connect(conn)
 }
 
-func (m *FullMockRedisClient) ConnectCluster(_ []string, _ string) error {
+func (m *FullMockRedisClient) ConnectCluster(_ []string, _ *types.Connection) error {
 	m.Calls = append(m.Calls, "ConnectCluster")
 	if m.ConnectClusterError != nil {
 		return m.ConnectClusterError
@@ -151,7 +151,7 @@ func (m *FullMockRedisClient) IsCluster() bool {
 	return m.IsClusterResult
 }
 
-func (m *FullMockRedisClient) TestConnection(conn *types.Connection) (time.Duration, error) {
+func (m *FullMockRedisClient) TestConnection(_ *types.Connection) (time.Duration, error) {
 	m.Calls = append(m.Calls, "TestConnection")
 	return m.TestConnectionLatency, m.TestConnectionError
 }

--- a/internal/testutil/mock_redis_full.go
+++ b/internal/testutil/mock_redis_full.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/davidbudnick/redis-tui/internal/types"
@@ -47,59 +46,59 @@ type FullMockRedisClient struct {
 	BitCountResult        int64
 
 	// Configurable errors (one per method)
-	ConnectClusterError    error
-	ConnectWithTLSError    error
-	TestConnectionError    error
-	SetStringError         error
-	SetTTLError            error
-	BatchSetTTLError       error
-	RPushError             error
-	LSetError              error
-	LRemError              error
-	SAddError              error
-	SRemError              error
-	ZAddError              error
-	ZRemError              error
-	HSetError              error
-	HDelError              error
-	XAddError              error
-	XDelError              error
-	SelectDBError          error
-	FlushDBError           error
-	ServerInfoError        error
-	MemStatsError          error
-	MemUsageError          error
-	SlowLogError           error
-	ClientListError        error
-	ClusterNodesError      error
-	ClusterInfoError       error
-	EvalError              error
-	PublishError           error
-	PubSubChannelsError    error
-	ConfigGetError         error
-	ConfigSetError         error
-	ExportError            error
-	ImportError            error
-	RenameError            error
-	CopyError              error
-	DeleteKeysError        error
-	BulkDeleteError        error
-	SearchByValueError     error
-	RegexSearchError       error
-	FuzzySearchError       error
-	CompareKeysError       error
-	KeyPrefixesError       error
+	ConnectClusterError     error
+	ConnectWithTLSError     error
+	TestConnectionError     error
+	SetStringError          error
+	SetTTLError             error
+	BatchSetTTLError        error
+	RPushError              error
+	LSetError               error
+	LRemError               error
+	SAddError               error
+	SRemError               error
+	ZAddError               error
+	ZRemError               error
+	HSetError               error
+	HDelError               error
+	XAddError               error
+	XDelError               error
+	SelectDBError           error
+	FlushDBError            error
+	ServerInfoError         error
+	MemStatsError           error
+	MemUsageError           error
+	SlowLogError            error
+	ClientListError         error
+	ClusterNodesError       error
+	ClusterInfoError        error
+	EvalError               error
+	PublishError            error
+	PubSubChannelsError     error
+	ConfigGetError          error
+	ConfigSetError          error
+	ExportError             error
+	ImportError             error
+	RenameError             error
+	CopyError               error
+	DeleteKeysError         error
+	BulkDeleteError         error
+	SearchByValueError      error
+	RegexSearchError        error
+	FuzzySearchError        error
+	CompareKeysError        error
+	KeyPrefixesError        error
 	SubscribeKeyspaceError  error
 	SubscribeKeyspaceEvents []types.KeyspaceEvent
-	UnsubscribeKSError     error
-	PFAddError             error
-	PFCountError           error
-	SetBitError            error
-	GetBitError            error
-	BitCountError          error
-	GeoAddError            error
-	GeoPosResult           []*redis.GeoPos
-	GeoPosError            error
+	UnsubscribeKSError      error
+	PFAddError              error
+	PFCountError            error
+	SetBitError             error
+	GetBitError             error
+	BitCountError           error
+	GeoAddError             error
+	GeoPosResult            []*redis.GeoPos
+	GeoPosError             error
 
 	// Call tracking
 	Calls []string
@@ -122,17 +121,6 @@ func (m *FullMockRedisClient) Connect(conn *types.Connection) error {
 
 	if m.ConnectWithTLSError != nil {
 		return m.ConnectWithTLSError
-	}
-
-	if conn.UseTLS {
-		if conn.TLSConfig == nil {
-			return fmt.Errorf("TLS requested but TLS configuration is missing")
-		}
-		_, err := conn.TLSConfig.BuildTLSConfig()
-		if err != nil {
-			return err
-		}
-		m.UsedTLS = true
 	}
 
 	return m.MockRedisClient.Connect(conn)

--- a/internal/testutil/mock_redis_full.go
+++ b/internal/testutil/mock_redis_full.go
@@ -116,7 +116,7 @@ func NewFullMockRedisClient() *FullMockRedisClient {
 
 // Connection management
 
-func (m *FullMockRedisClient) Connect(conn *types.Connection) error {
+func (m *FullMockRedisClient) Connect(conn types.Connection) error {
 	m.Calls = append(m.Calls, "Connect")
 
 	if m.ConnectWithTLSError != nil {
@@ -126,20 +126,20 @@ func (m *FullMockRedisClient) Connect(conn *types.Connection) error {
 	return m.MockRedisClient.Connect(conn)
 }
 
-func (m *FullMockRedisClient) ConnectCluster(_ []string, _ *types.Connection) error {
+func (m *FullMockRedisClient) ConnectCluster(_ []string, _ types.Connection) error {
 	m.Calls = append(m.Calls, "ConnectCluster")
 	if m.ConnectClusterError != nil {
 		return m.ConnectClusterError
 	}
 	conn := types.Connection{Name: "", Host: "", Port: 0, UseCluster: true}
-	return m.MockRedisClient.Connect(&conn)
+	return m.MockRedisClient.Connect(conn)
 }
 
 func (m *FullMockRedisClient) IsCluster() bool {
 	return m.IsClusterResult
 }
 
-func (m *FullMockRedisClient) TestConnection(_ *types.Connection) (time.Duration, error) {
+func (m *FullMockRedisClient) TestConnection(_ types.Connection) (time.Duration, error) {
 	m.Calls = append(m.Calls, "TestConnection")
 	return m.TestConnectionLatency, m.TestConnectionError
 }

--- a/internal/testutil/mock_redis_full.go
+++ b/internal/testutil/mock_redis_full.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"crypto/tls"
 	"time"
 
 	"github.com/davidbudnick/redis-tui/internal/types"
@@ -114,32 +113,25 @@ func NewFullMockRedisClient() *FullMockRedisClient {
 
 // Connection management
 
-func (m *FullMockRedisClient) Connect(host string, port int, password string, db int) error {
+func (m *FullMockRedisClient) Connect(conn *types.Connection) error {
 	m.Calls = append(m.Calls, "Connect")
-	return m.MockRedisClient.Connect(host, port, password, db)
+	return m.MockRedisClient.Connect(conn)
 }
 
-func (m *FullMockRedisClient) ConnectWithTLS(_ string, _ int, _ string, _ int, _ *tls.Config) error {
-	m.Calls = append(m.Calls, "ConnectWithTLS")
-	if m.ConnectWithTLSError != nil {
-		return m.ConnectWithTLSError
-	}
-	return m.MockRedisClient.Connect("", 0, "", 0)
-}
-
-func (m *FullMockRedisClient) ConnectCluster(_ []string, _ string) error {
+func (m *FullMockRedisClient) ConnectCluster(_ []string, _ string, _ string) error {
 	m.Calls = append(m.Calls, "ConnectCluster")
 	if m.ConnectClusterError != nil {
 		return m.ConnectClusterError
 	}
-	return m.MockRedisClient.Connect("", 0, "", 0)
+	conn := types.Connection{Name: "", Host: "", Port: 0, UseCluster: true}
+	return m.MockRedisClient.Connect(&conn)
 }
 
 func (m *FullMockRedisClient) IsCluster() bool {
 	return m.IsClusterResult
 }
 
-func (m *FullMockRedisClient) TestConnection(_ string, _ int, _ string, _ int) (time.Duration, error) {
+func (m *FullMockRedisClient) TestConnection(conn *types.Connection) (time.Duration, error) {
 	m.Calls = append(m.Calls, "TestConnection")
 	return m.TestConnectionLatency, m.TestConnectionError
 }

--- a/internal/testutil/mock_redis_full.go
+++ b/internal/testutil/mock_redis_full.go
@@ -118,7 +118,7 @@ func (m *FullMockRedisClient) Connect(conn *types.Connection) error {
 	return m.MockRedisClient.Connect(conn)
 }
 
-func (m *FullMockRedisClient) ConnectCluster(_ []string, _ string, _ string) error {
+func (m *FullMockRedisClient) ConnectCluster(_ []string, _ string) error {
 	m.Calls = append(m.Calls, "ConnectCluster")
 	if m.ConnectClusterError != nil {
 		return m.ConnectClusterError

--- a/internal/testutil/mock_redis_full.go
+++ b/internal/testutil/mock_redis_full.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/davidbudnick/redis-tui/internal/types"
@@ -102,6 +103,9 @@ type FullMockRedisClient struct {
 
 	// Call tracking
 	Calls []string
+
+	// Track TLS usage
+	UsedTLS bool
 }
 
 // NewFullMockRedisClient creates a new fully-mocked Redis client.
@@ -115,6 +119,22 @@ func NewFullMockRedisClient() *FullMockRedisClient {
 
 func (m *FullMockRedisClient) Connect(conn *types.Connection) error {
 	m.Calls = append(m.Calls, "Connect")
+
+	if m.ConnectWithTLSError != nil {
+		return m.ConnectWithTLSError
+	}
+
+	if conn.UseTLS {
+		if conn.TLSConfig == nil {
+			return fmt.Errorf("TLS requested but TLS configuration is missing")
+		}
+		_, err := conn.TLSConfig.BuildTLSConfig()
+		if err != nil {
+			return err
+		}
+		m.UsedTLS = true
+	}
+
 	return m.MockRedisClient.Connect(conn)
 }
 

--- a/internal/testutil/mock_redis_full_test.go
+++ b/internal/testutil/mock_redis_full_test.go
@@ -30,7 +30,7 @@ func TestFullMockRedisClient_NewDefaults(t *testing.T) {
 
 func TestFullMockRedisClient_CallTracking(t *testing.T) {
 	m := NewFullMockRedisClient()
-	_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+	_ = m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	m.SetIncludeTypes(true)
 	_ = m.FlushDB()
 	_ = m.SelectDB(0)
@@ -47,7 +47,7 @@ func TestFullMockRedisClient_CallTracking(t *testing.T) {
 func TestFullMockRedisClient_Connect(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := NewFullMockRedisClient()
-		err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		err := m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		AssertNoError(t, err, "Connect")
 		AssertSliceLen(t, m.Calls, 1, "Calls after Connect")
 		AssertEqual(t, m.Calls[0], "Connect", "call name")
@@ -59,7 +59,7 @@ func TestFullMockRedisClient_Connect(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		m := NewFullMockRedisClient()
 		m.ConnectError = errTest
-		err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		err := m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		if !errors.Is(err, errTest) {
 			t.Errorf("expected errTest, got %v", err)
 		}
@@ -69,7 +69,7 @@ func TestFullMockRedisClient_Connect(t *testing.T) {
 func TestFullMockRedisClient_ConnectCluster(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := NewFullMockRedisClient()
-		err := m.ConnectCluster([]string{"localhost:6379"}, &types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		err := m.ConnectCluster([]string{"localhost:6379"}, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		AssertNoError(t, err, "ConnectCluster")
 		AssertEqual(t, m.Calls[0], "ConnectCluster", "call name")
 		if !m.IsConnected() {
@@ -80,7 +80,7 @@ func TestFullMockRedisClient_ConnectCluster(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		m := NewFullMockRedisClient()
 		m.ConnectClusterError = errTest
-		err := m.ConnectCluster([]string{"localhost:6379"}, &types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		err := m.ConnectCluster([]string{"localhost:6379"}, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		if !errors.Is(err, errTest) {
 			t.Errorf("expected errTest, got %v", err)
 		}
@@ -98,7 +98,7 @@ func TestFullMockRedisClient_TestConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := NewFullMockRedisClient()
 		m.TestConnectionLatency = 42 * time.Millisecond
-		latency, err := m.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		latency, err := m.TestConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		AssertNoError(t, err, "TestConnection")
 		AssertEqual(t, latency, 42*time.Millisecond, "latency")
 		AssertEqual(t, m.Calls[0], "TestConnection", "call name")
@@ -107,7 +107,7 @@ func TestFullMockRedisClient_TestConnection(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		m := NewFullMockRedisClient()
 		m.TestConnectionError = errTest
-		_, err := m.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		_, err := m.TestConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		if !errors.Is(err, errTest) {
 			t.Errorf("expected errTest, got %v", err)
 		}

--- a/internal/testutil/mock_redis_full_test.go
+++ b/internal/testutil/mock_redis_full_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
 var errTest = errors.New("test error")
@@ -28,7 +30,7 @@ func TestFullMockRedisClient_NewDefaults(t *testing.T) {
 
 func TestFullMockRedisClient_CallTracking(t *testing.T) {
 	m := NewFullMockRedisClient()
-	_ = m.Connect("localhost", 6379, "", 0)
+	_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	m.SetIncludeTypes(true)
 	_ = m.FlushDB()
 	_ = m.SelectDB(0)
@@ -45,7 +47,7 @@ func TestFullMockRedisClient_CallTracking(t *testing.T) {
 func TestFullMockRedisClient_Connect(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := NewFullMockRedisClient()
-		err := m.Connect("localhost", 6379, "", 0)
+		err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		AssertNoError(t, err, "Connect")
 		AssertSliceLen(t, m.Calls, 1, "Calls after Connect")
 		AssertEqual(t, m.Calls[0], "Connect", "call name")
@@ -57,28 +59,7 @@ func TestFullMockRedisClient_Connect(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		m := NewFullMockRedisClient()
 		m.ConnectError = errTest
-		err := m.Connect("localhost", 6379, "", 0)
-		if !errors.Is(err, errTest) {
-			t.Errorf("expected errTest, got %v", err)
-		}
-	})
-}
-
-func TestFullMockRedisClient_ConnectWithTLS(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		m := NewFullMockRedisClient()
-		err := m.ConnectWithTLS("localhost", 6379, "", 0, nil)
-		AssertNoError(t, err, "ConnectWithTLS")
-		AssertEqual(t, m.Calls[0], "ConnectWithTLS", "call name")
-		if !m.IsConnected() {
-			t.Error("expected connected")
-		}
-	})
-
-	t.Run("error", func(t *testing.T) {
-		m := NewFullMockRedisClient()
-		m.ConnectWithTLSError = errTest
-		err := m.ConnectWithTLS("localhost", 6379, "", 0, nil)
+		err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		if !errors.Is(err, errTest) {
 			t.Errorf("expected errTest, got %v", err)
 		}
@@ -88,7 +69,7 @@ func TestFullMockRedisClient_ConnectWithTLS(t *testing.T) {
 func TestFullMockRedisClient_ConnectCluster(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := NewFullMockRedisClient()
-		err := m.ConnectCluster([]string{"localhost:6379"}, "")
+		err := m.ConnectCluster([]string{"localhost:6379"}, &types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		AssertNoError(t, err, "ConnectCluster")
 		AssertEqual(t, m.Calls[0], "ConnectCluster", "call name")
 		if !m.IsConnected() {
@@ -99,7 +80,7 @@ func TestFullMockRedisClient_ConnectCluster(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		m := NewFullMockRedisClient()
 		m.ConnectClusterError = errTest
-		err := m.ConnectCluster([]string{"localhost:6379"}, "")
+		err := m.ConnectCluster([]string{"localhost:6379"}, &types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		if !errors.Is(err, errTest) {
 			t.Errorf("expected errTest, got %v", err)
 		}
@@ -117,7 +98,7 @@ func TestFullMockRedisClient_TestConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		m := NewFullMockRedisClient()
 		m.TestConnectionLatency = 42 * time.Millisecond
-		latency, err := m.TestConnection("localhost", 6379, "", 0)
+		latency, err := m.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		AssertNoError(t, err, "TestConnection")
 		AssertEqual(t, latency, 42*time.Millisecond, "latency")
 		AssertEqual(t, m.Calls[0], "TestConnection", "call name")
@@ -126,7 +107,7 @@ func TestFullMockRedisClient_TestConnection(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		m := NewFullMockRedisClient()
 		m.TestConnectionError = errTest
-		_, err := m.TestConnection("localhost", 6379, "", 0)
+		_, err := m.TestConnection(&types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 		if !errors.Is(err, errTest) {
 			t.Errorf("expected errTest, got %v", err)
 		}

--- a/internal/testutil/mock_redis_test.go
+++ b/internal/testutil/mock_redis_test.go
@@ -62,7 +62,7 @@ func TestMockRedisClient_Disconnected(t *testing.T) {
 
 func TestMockRedisClient_Connected(t *testing.T) {
 	m := NewMockRedisClient()
-	if err := m.Connect("localhost", 6379, "", 0); err != nil {
+	if err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect failed: %v", err)
 	}
 
@@ -120,7 +120,7 @@ func TestMockRedisClient_Connected(t *testing.T) {
 
 func TestMockRedisClient_Reset(t *testing.T) {
 	m := NewMockRedisClient()
-	_ = m.Connect("localhost", 6379, "", 0)
+	_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 	m.SetKey("key1", types.RedisValue{}, types.KeyTypeString, 0)
 
 	m.Reset()
@@ -137,7 +137,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 	t.Run("ConnectError", func(t *testing.T) {
 		m := NewMockRedisClient()
 		m.ConnectError = ErrMockNotConnected
-		err := m.Connect("localhost", 6379, "", 0)
+		err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		if err != ErrMockNotConnected {
 			t.Errorf("expected ErrMockNotConnected, got %v", err)
 		}
@@ -145,7 +145,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 	t.Run("DisconnectError", func(t *testing.T) {
 		m := NewMockRedisClient()
-		_ = m.Connect("localhost", 6379, "", 0)
+		_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		m.DisconnectError = ErrMockNotConnected
 		err := m.Disconnect()
 		if err != ErrMockNotConnected {
@@ -155,7 +155,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 	t.Run("ScanError", func(t *testing.T) {
 		m := NewMockRedisClient()
-		_ = m.Connect("localhost", 6379, "", 0)
+		_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		m.ScanError = ErrMockNotConnected
 		_, _, err := m.ScanKeys("*", 0, 10)
 		if err != ErrMockNotConnected {
@@ -165,7 +165,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 	t.Run("GetError", func(t *testing.T) {
 		m := NewMockRedisClient()
-		_ = m.Connect("localhost", 6379, "", 0)
+		_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		m.SetKey("key", types.RedisValue{}, types.KeyTypeString, 0)
 		m.GetError = ErrMockNotConnected
 		_, err := m.GetValue("key")
@@ -176,7 +176,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 	t.Run("DeleteError", func(t *testing.T) {
 		m := NewMockRedisClient()
-		_ = m.Connect("localhost", 6379, "", 0)
+		_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		m.DeleteError = ErrMockNotConnected
 		err := m.DeleteKey("key")
 		if err != ErrMockNotConnected {
@@ -203,7 +203,7 @@ func TestMockRedisClient_DisconnectSuccess(t *testing.T) {
 
 func TestMockRedisClient_TTLStored(t *testing.T) {
 	m := NewMockRedisClient()
-	_ = m.Connect("localhost", 6379, "", 0)
+	_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 	m.SetKey("ttlkey", types.RedisValue{}, types.KeyTypeString, 5*time.Second)
 
 	keys, _, err := m.ScanKeys("*", 0, 10)

--- a/internal/testutil/mock_redis_test.go
+++ b/internal/testutil/mock_redis_test.go
@@ -187,7 +187,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 func TestMockRedisClient_DisconnectSuccess(t *testing.T) {
 	m := NewMockRedisClient()
-	if err := m.Connect("localhost", 6379, "", 0); err != nil {
+	if err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect failed: %v", err)
 	}
 	if !m.IsConnected() {

--- a/internal/testutil/mock_redis_test.go
+++ b/internal/testutil/mock_redis_test.go
@@ -62,7 +62,7 @@ func TestMockRedisClient_Disconnected(t *testing.T) {
 
 func TestMockRedisClient_Connected(t *testing.T) {
 	m := NewMockRedisClient()
-	if err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false}); err != nil {
+	if err := m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect failed: %v", err)
 	}
 
@@ -120,7 +120,7 @@ func TestMockRedisClient_Connected(t *testing.T) {
 
 func TestMockRedisClient_Reset(t *testing.T) {
 	m := NewMockRedisClient()
-	_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
+	_ = m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 	m.SetKey("key1", types.RedisValue{}, types.KeyTypeString, 0)
 
 	m.Reset()
@@ -137,7 +137,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 	t.Run("ConnectError", func(t *testing.T) {
 		m := NewMockRedisClient()
 		m.ConnectError = ErrMockNotConnected
-		err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
+		err := m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		if err != ErrMockNotConnected {
 			t.Errorf("expected ErrMockNotConnected, got %v", err)
 		}
@@ -145,7 +145,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 	t.Run("DisconnectError", func(t *testing.T) {
 		m := NewMockRedisClient()
-		_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
+		_ = m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		m.DisconnectError = ErrMockNotConnected
 		err := m.Disconnect()
 		if err != ErrMockNotConnected {
@@ -155,7 +155,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 	t.Run("ScanError", func(t *testing.T) {
 		m := NewMockRedisClient()
-		_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
+		_ = m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		m.ScanError = ErrMockNotConnected
 		_, _, err := m.ScanKeys("*", 0, 10)
 		if err != ErrMockNotConnected {
@@ -165,7 +165,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 	t.Run("GetError", func(t *testing.T) {
 		m := NewMockRedisClient()
-		_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
+		_ = m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		m.SetKey("key", types.RedisValue{}, types.KeyTypeString, 0)
 		m.GetError = ErrMockNotConnected
 		_, err := m.GetValue("key")
@@ -176,7 +176,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 	t.Run("DeleteError", func(t *testing.T) {
 		m := NewMockRedisClient()
-		_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
+		_ = m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 		m.DeleteError = ErrMockNotConnected
 		err := m.DeleteKey("key")
 		if err != ErrMockNotConnected {
@@ -187,7 +187,7 @@ func TestMockRedisClient_ConfigurableErrors(t *testing.T) {
 
 func TestMockRedisClient_DisconnectSuccess(t *testing.T) {
 	m := NewMockRedisClient()
-	if err := m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false}); err != nil {
+	if err := m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect failed: %v", err)
 	}
 	if !m.IsConnected() {
@@ -203,7 +203,7 @@ func TestMockRedisClient_DisconnectSuccess(t *testing.T) {
 
 func TestMockRedisClient_TTLStored(t *testing.T) {
 	m := NewMockRedisClient()
-	_ = m.Connect(&types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
+	_ = m.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "", DB: 0, UseCluster: false})
 	m.SetKey("ttlkey", types.RedisValue{}, types.KeyTypeString, 5*time.Second)
 
 	keys, _, err := m.ScanKeys("*", 0, 10)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -2,9 +2,17 @@
 package testutil
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/davidbudnick/redis-tui/internal/db"
 	"github.com/davidbudnick/redis-tui/internal/types"
@@ -143,5 +151,36 @@ func SampleFavorite(connID int64, key string) types.Favorite {
 		ConnectionID: connID,
 		Key:          key,
 		Label:        "Test Favorite",
+	}
+}
+
+// GenerateEphemeralCert generates an ephemeral TLS certificate for testing.
+func GenerateEphemeralCert(t testing.TB) tls.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ephemeral TLS certificate: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Redis TUI Test"},
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("failed to generate ephemeral TLS certificate: %v", err)
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{derBytes},
+		PrivateKey:  priv,
 	}
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -39,9 +39,9 @@ func NewTestConfig(t testing.TB) *db.Config {
 }
 
 // MustAddConnection adds a connection to the config or fails the test.
-func MustAddConnection(t testing.TB, cfg *db.Config, name, host string, port int, password string, dbNum int) types.Connection {
+func MustAddConnection(t *testing.T, cfg *db.Config, conn types.Connection) types.Connection {
 	t.Helper()
-	conn, err := cfg.AddConnection(name, host, port, password, dbNum, false)
+	conn, err := cfg.AddConnection(conn)
 	if err != nil {
 		t.Fatalf("failed to add connection: %v", err)
 	}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -39,7 +39,7 @@ func NewTestConfig(t testing.TB) *db.Config {
 }
 
 // MustAddConnection adds a connection to the config or fails the test.
-func MustAddConnection(t *testing.T, cfg *db.Config, conn types.Connection) types.Connection {
+func MustAddConnection(t testing.TB, cfg *db.Config, conn types.Connection) types.Connection {
 	t.Helper()
 	conn, err := cfg.AddConnection(conn)
 	if err != nil {

--- a/internal/testutil/testutil_failure_test.go
+++ b/internal/testutil/testutil_failure_test.go
@@ -122,7 +122,7 @@ func TestAssertConnectionExists_NotFound(t *testing.T) {
 
 func TestAssertConnectionNotExists_FoundFails(t *testing.T) {
 	cfg := NewTestConfig(t)
-	conn := MustAddConnection(t, cfg, "name", "localhost", 6379, "", 0)
+	conn := MustAddConnection(t, cfg, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	f := runWithFakeTB(t, func(tb testing.TB) {
 		AssertConnectionNotExists(tb, cfg, conn.ID)
 	})
@@ -188,20 +188,19 @@ func TestMustAddConnection_Failure(t *testing.T) {
 		t.Fatalf("NewConfig: %v", err)
 	}
 	// Make the directory read-only so save() fails on AddConnection.
-	if err := os.Chmod(dir, 0500); err != nil {
+	if err := os.Chmod(dir, 0o500); err != nil {
 		t.Fatalf("chmod dir: %v", err)
 	}
 	t.Cleanup(func() {
-		if err := os.Chmod(dir, 0700); err != nil {
+		if err := os.Chmod(dir, 0o700); err != nil {
 			t.Logf("restore dir perms: %v", err)
 		}
 	})
 
 	f := runWithFakeTB(t, func(tb testing.TB) {
-		MustAddConnection(tb, cfg, "name", "localhost", 6379, "", 0)
+		MustAddConnection(tb, cfg, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	})
 	if !f.didFail() {
 		t.Error("expected MustAddConnection to fail when save errors")
 	}
 }
-

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -39,7 +39,7 @@ func TestNewTestConfig(t *testing.T) {
 
 func TestMustAddConnection(t *testing.T) {
 	cfg := NewTestConfig(t)
-	conn := MustAddConnection(t, cfg, "test", "localhost", 6379, "", 0)
+	conn := MustAddConnection(t, cfg, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	if conn.Name != "test" {
 		t.Errorf("Name = %q, want %q", conn.Name, "test")
 	}
@@ -53,7 +53,7 @@ func TestMustAddConnection(t *testing.T) {
 
 func TestAssertConnectionExists(t *testing.T) {
 	cfg := NewTestConfig(t)
-	conn := MustAddConnection(t, cfg, "test", "localhost", 6379, "", 0)
+	conn := MustAddConnection(t, cfg, types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
 	got := AssertConnectionExists(t, cfg, conn.ID)
 	if got.Name != "test" {
 		t.Errorf("Name = %q, want %q", got.Name, "test")
@@ -93,7 +93,7 @@ func TestFileExists(t *testing.T) {
 		t.Error("FileExists should return false for non-existent file")
 	}
 
-	err := os.WriteFile(path, []byte("test"), 0600)
+	err := os.WriteFile(path, []byte("test"), 0o600)
 	if err != nil {
 		t.Fatalf("failed to write test file: %v", err)
 	}

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -14,7 +14,7 @@ type Connection struct {
 	Name       string     `json:"name"`
 	Host       string     `json:"host"`
 	Port       int        `json:"port"`
-	Password   string     `json:"-"` // #nosec G117 -- stored in local user config. - ensures marshal never returns value
+	Password   string     `json:"password,omitempty"` // #nosec G117 -- stored in local user config.
 	DB         int        `json:"db"`
 	Group      string     `json:"group,omitempty"`
 	Color      string     `json:"color,omitempty"`
@@ -32,9 +32,9 @@ type SSHConfig struct {
 	Host           string `json:"host"`
 	Port           int    `json:"port"`
 	User           string `json:"user"`
-	Password       string `json:"-"` // #nosec G117 -- stored in local user config - ensures marshal never returns value
+	Password       string `json:"password,omitempty"` // #nosec G117 -- stored in local user config.
 	PrivateKeyPath string `json:"private_key_path,omitempty"`
-	Passphrase     string `json:"-"` // #nosec G117 -- stored in local user config - ensures marshal never returns value
+	Passphrase     string `json:"passphrase,omitempty"`
 }
 
 // TLSConfig stores TLS/SSL configuration

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -10,21 +10,21 @@ import (
 
 // Connection stores Redis connection details
 type Connection struct {
-	ID        int64      `json:"id"`
-	Name      string     `json:"name"`
-	Host      string     `json:"host"`
-	Port      int        `json:"port"`
-	Password  string     `json:"password,omitempty"` // #nosec G117 -- stored in local user config
-	DB        int        `json:"db"`
-	Group     string     `json:"group,omitempty"`
-	Color     string     `json:"color,omitempty"`
-	UseSSH    bool       `json:"use_ssh,omitempty"`
-	SSHConfig *SSHConfig `json:"ssh_config,omitempty"`
+	ID         int64      `json:"id"`
+	Name       string     `json:"name"`
+	Host       string     `json:"host"`
+	Port       int        `json:"port"`
+	Password   string     `json:"-"` // #nosec G117 -- stored in local user config. - ensures marshal never returns value
+	DB         int        `json:"db"`
+	Group      string     `json:"group,omitempty"`
+	Color      string     `json:"color,omitempty"`
+	UseSSH     bool       `json:"use_ssh,omitempty"`
+	SSHConfig  *SSHConfig `json:"ssh_config,omitempty"`
 	UseTLS     bool       `json:"use_tls,omitempty"`
 	TLSConfig  *TLSConfig `json:"tls_config,omitempty"`
 	UseCluster bool       `json:"use_cluster,omitempty"`
-	Created   time.Time  `json:"created_at"`
-	Updated   time.Time  `json:"updated_at"`
+	Created    time.Time  `json:"created_at"`
+	Updated    time.Time  `json:"updated_at"`
 }
 
 // SSHConfig stores SSH tunnel configuration
@@ -32,9 +32,9 @@ type SSHConfig struct {
 	Host           string `json:"host"`
 	Port           int    `json:"port"`
 	User           string `json:"user"`
-	Password       string `json:"password,omitempty"` // #nosec G117 -- stored in local user config
+	Password       string `json:"-"` // #nosec G117 -- stored in local user config - ensures marshal never returns value
 	PrivateKeyPath string `json:"private_key_path,omitempty"`
-	Passphrase     string `json:"passphrase,omitempty"`
+	Passphrase     string `json:"-"` // #nosec G117 -- stored in local user config - ensures marshal never returns value
 }
 
 // TLSConfig stores TLS/SSL configuration

--- a/internal/ui/messages_connection.go
+++ b/internal/ui/messages_connection.go
@@ -14,7 +14,7 @@ func (m Model) handleAutoConnectMsg(msg types.AutoConnectMsg) (tea.Model, tea.Cm
 	m.Loading = true
 	m.StatusMsg = "Connecting..."
 	m.CLIConnection = nil // Consume so it doesn't re-trigger
-	return m, m.Cmds.Connect(m.CurrentConn)
+	return m, m.Cmds.Connect(conn)
 }
 
 func (m Model) handleConnectionsLoadedMsg(msg types.ConnectionsLoadedMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/messages_connection.go
+++ b/internal/ui/messages_connection.go
@@ -14,7 +14,7 @@ func (m Model) handleAutoConnectMsg(msg types.AutoConnectMsg) (tea.Model, tea.Cm
 	m.Loading = true
 	m.StatusMsg = "Connecting..."
 	m.CLIConnection = nil // Consume so it doesn't re-trigger
-	return m, m.Cmds.AutoConnect(conn)
+	return m, m.Cmds.Connect(m.CurrentConn)
 }
 
 func (m Model) handleConnectionsLoadedMsg(msg types.ConnectionsLoadedMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -334,22 +334,6 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-func (m *Model) convertCurrentInputsToConnection(inputs []textinput.Model, action string) types.Connection {
-	var id int64
-	if action == "edit" {
-		id = m.EditingConnection.ID
-	}
-	return types.Connection{
-		ID:         id,
-		Name:       inputs[0].Value(),
-		Host:       inputs[1].Value(),
-		Port:       m.getPort(),
-		Password:   inputs[3].Value(),
-		DB:         m.getDB(),
-		UseCluster: m.ConnClusterMode,
-	}
-}
-
 func (m Model) getPort() int {
 	port, err := strconv.Atoi(m.ConnInputs[2].Value())
 	if err != nil {
@@ -398,6 +382,23 @@ func (m *Model) populateConnInputs(conn types.Connection) {
 	m.ConnInputs[3].SetValue(conn.Password)
 	m.ConnInputs[4].SetValue(strconv.Itoa(conn.DB))
 	m.ConnClusterMode = conn.UseCluster
+}
+
+// convertCurrentInputsToConnection converts the current inputs to a connection
+func (m *Model) convertCurrentInputsToConnection(inputs []textinput.Model, action string) types.Connection {
+	var id int64
+	if action == "edit" && m.EditingConnection != nil {
+		id = m.EditingConnection.ID
+	}
+	return types.Connection{
+		ID:         id,
+		Name:       inputs[0].Value(),
+		Host:       inputs[1].Value(),
+		Port:       m.getPort(),
+		Password:   inputs[3].Value(),
+		DB:         m.getDB(),
+		UseCluster: m.ConnClusterMode,
+	}
 }
 
 // connFieldCount returns the number of focusable fields in the connection form.

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -49,7 +49,7 @@ type Model struct {
 	PendingSelectKey  string
 
 	// New fields for additional features
-	VimEditor vimtea.Editor
+	VimEditor          vimtea.Editor
 	EditingIndex       int
 	EditingField       string
 	AddCollectionInput []textinput.Model
@@ -165,7 +165,7 @@ type Model struct {
 	PreviewKey    string
 	PreviewValue  types.RedisValue
 	PreviewScroll int
-	DetailScroll int
+	DetailScroll  int
 
 	// Live metrics dashboard
 	LiveMetrics       *types.LiveMetrics
@@ -332,6 +332,22 @@ func (m Model) Init() tea.Cmd {
 		})
 	}
 	return tea.Batch(cmds...)
+}
+
+func (m *Model) convertCurrentInputsToConnection(inputs []textinput.Model, action string) types.Connection {
+	var id int64
+	if action == "edit" {
+		id = m.EditingConnection.ID
+	}
+	return types.Connection{
+		ID:         id,
+		Name:       inputs[0].Value(),
+		Host:       inputs[1].Value(),
+		Port:       m.getPort(),
+		Password:   inputs[3].Value(),
+		DB:         m.getDB(),
+		UseCluster: m.ConnClusterMode,
+	}
 }
 
 func (m Model) getPort() int {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -191,6 +191,15 @@ type Model struct {
 	inputsInitialized bool
 }
 
+type ActionType string
+
+const (
+	ActionAdd    ActionType = "add"
+	ActionEdit   ActionType = "edit"
+	ActionDelete ActionType = "delete"
+	ActionTest   ActionType = "test"
+)
+
 func NewModel() Model {
 	return Model{
 		Screen:             types.ScreenConnections,
@@ -385,7 +394,7 @@ func (m *Model) populateConnInputs(conn types.Connection) {
 }
 
 // convertCurrentInputsToConnection converts the current inputs to a connection
-func (m *Model) convertCurrentInputsToConnection(inputs []textinput.Model, action string) types.Connection {
+func (m *Model) convertCurrentInputsToConnection(inputs []textinput.Model, action ActionType) types.Connection {
 	var id int64
 	if action == "edit" && m.EditingConnection != nil {
 		id = m.EditingConnection.ID

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -390,13 +390,16 @@ func (m *Model) convertCurrentInputsToConnection(inputs []textinput.Model, actio
 	if action == "edit" && m.EditingConnection != nil {
 		id = m.EditingConnection.ID
 	}
+
+	port, _ := strconv.Atoi(inputs[2].Value())
+	db, _ := strconv.Atoi(inputs[4].Value())
 	return types.Connection{
 		ID:         id,
 		Name:       inputs[0].Value(),
+		Port:       port,
 		Host:       inputs[1].Value(),
-		Port:       m.getPort(),
 		Password:   inputs[3].Value(),
-		DB:         m.getDB(),
+		DB:         db,
 		UseCluster: m.ConnClusterMode,
 	}
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -213,6 +213,80 @@ func TestModel_PopulateConnInputs(t *testing.T) {
 	}
 }
 
+func TestModel_ConvertCurrentInputsToConnection_Add(t *testing.T) {
+	m := NewModel()
+
+	// Set some values / m state
+	m.ConnInputs[0].SetValue("My Connection")
+	m.ConnInputs[1].SetValue("redis.example.com")
+	m.ConnInputs[2].SetValue("6380")
+	m.ConnInputs[3].SetValue("secret")
+	m.ConnInputs[4].SetValue("5")
+	m.ConnClusterMode = true
+	m.ConnFocusIdx = 3
+
+	// Convert
+	conn := m.convertCurrentInputsToConnection(m.ConnInputs, "add")
+
+	if conn.Name != "My Connection" {
+		t.Errorf("Name = %q, want %q", conn.Name, "My Connection")
+	}
+	if conn.Host != "redis.example.com" {
+		t.Errorf("Host = %q, want %q", conn.Host, "redis.example.com")
+	}
+	if conn.Port != 6380 {
+		t.Errorf("Port = %d, want %d", conn.Port, 6380)
+	}
+	if conn.Password != "secret" {
+		t.Errorf("Password = %q, want %q", conn.Password, "secret")
+	}
+	if conn.DB != 5 {
+		t.Errorf("DB = %d, want %d", conn.DB, 5)
+	}
+	if conn.UseCluster != true {
+		t.Errorf("UseCluster = %v, want %v", conn.UseCluster, true)
+	}
+}
+
+func TestModel_ConvertCurrentInputsToConnection_Edit(t *testing.T) {
+	m := NewModel()
+
+	// Set some values / m state
+	m.EditingConnection = &types.Connection{ID: 1, Name: "Old", Host: "localhost", Port: 6379, DB: 0, UseCluster: false}
+	m.ConnInputs[0].SetValue("My Connection")
+	m.ConnInputs[1].SetValue("redis.example.com")
+	m.ConnInputs[2].SetValue("6380")
+	m.ConnInputs[3].SetValue("secret")
+	m.ConnInputs[4].SetValue("5")
+	m.ConnClusterMode = true
+	m.ConnFocusIdx = 3
+
+	// Convert
+	conn := m.convertCurrentInputsToConnection(m.ConnInputs, "edit")
+
+	if conn.Name != "My Connection" {
+		t.Errorf("Name = %q, want %q", conn.Name, "My Connection")
+	}
+	if conn.Host != "redis.example.com" {
+		t.Errorf("Host = %q, want %q", conn.Host, "redis.example.com")
+	}
+	if conn.Port != 6380 {
+		t.Errorf("Port = %d, want %d", conn.Port, 6380)
+	}
+	if conn.Password != "secret" {
+		t.Errorf("Password = %q, want %q", conn.Password, "secret")
+	}
+	if conn.DB != 5 {
+		t.Errorf("DB = %d, want %d", conn.DB, 5)
+	}
+	if conn.UseCluster != true {
+		t.Errorf("UseCluster = %v, want %v", conn.UseCluster, true)
+	}
+	if conn.ID != 1 {
+		t.Errorf("ID = %d, want %d", conn.ID, 1)
+	}
+}
+
 func TestModel_ResetAddCollectionInputs(t *testing.T) {
 	m := NewModel()
 

--- a/internal/ui/screens_connection.go
+++ b/internal/ui/screens_connection.go
@@ -25,7 +25,7 @@ func (m Model) handleConnectionsScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.Loading = true
 			m.StatusMsg = "Connecting..."
 			m.ConnectionError = "" // Clear any previous connection error
-			return m, m.Cmds.Connect(conn.Host, conn.Port, conn.Password, conn.DB, conn.UseCluster)
+			return m, m.Cmds.Connect(m.CurrentConn)
 		}
 	case "a", "n":
 		m.Screen = types.ScreenAddConnection
@@ -82,23 +82,17 @@ func (m Model) handleAddConnectionScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if m.ConnInputs[0].Value() != "" && m.ConnInputs[1].Value() != "" {
 			m.Loading = true
+			conn := m.convertCurrentInputsToConnection(m.ConnInputs, "add")
 			return m, m.Cmds.AddConnection(
-				m.ConnInputs[0].Value(),
-				m.ConnInputs[1].Value(),
-				m.getPort(),
-				m.ConnInputs[3].Value(),
-				m.getDB(),
-				m.ConnClusterMode,
+				conn,
 			)
 		}
 	case "ctrl+t":
 		m.Loading = true
 		m.Screen = types.ScreenTestConnection
+		conn := m.convertCurrentInputsToConnection(m.ConnInputs, "test")
 		return m, m.Cmds.TestConnection(
-			m.ConnInputs[1].Value(),
-			m.getPort(),
-			m.ConnInputs[3].Value(),
-			m.getDB(),
+			&conn,
 		)
 	case "esc":
 		m.Screen = types.ScreenConnections
@@ -178,14 +172,9 @@ func (m Model) handleEditConnectionScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if m.EditingConnection != nil && m.ConnInputs[0].Value() != "" && m.ConnInputs[1].Value() != "" {
 			m.Loading = true
+			conn := m.convertCurrentInputsToConnection(m.ConnInputs, "edit")
 			return m, m.Cmds.UpdateConnection(
-				m.EditingConnection.ID,
-				m.ConnInputs[0].Value(),
-				m.ConnInputs[1].Value(),
-				m.getPort(),
-				m.ConnInputs[3].Value(),
-				m.getDB(),
-				m.ConnClusterMode,
+				conn,
 			)
 		}
 	case "esc":

--- a/internal/ui/screens_connection.go
+++ b/internal/ui/screens_connection.go
@@ -25,7 +25,7 @@ func (m Model) handleConnectionsScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.Loading = true
 			m.StatusMsg = "Connecting..."
 			m.ConnectionError = "" // Clear any previous connection error
-			return m, m.Cmds.Connect(m.CurrentConn)
+			return m, m.Cmds.Connect(conn)
 		}
 	case "a", "n":
 		m.Screen = types.ScreenAddConnection
@@ -92,7 +92,7 @@ func (m Model) handleAddConnectionScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.Screen = types.ScreenTestConnection
 		conn := m.convertCurrentInputsToConnection(m.ConnInputs, "test")
 		return m, m.Cmds.TestConnection(
-			&conn,
+			conn,
 		)
 	case "esc":
 		m.Screen = types.ScreenConnections

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func initConfig() (*db.Config, error) {
 	}
 
 	configDir := filepath.Join(homeDir, ".config", "redis-tui")
-	if err := os.MkdirAll(configDir, 0750); err != nil {
+	if err := os.MkdirAll(configDir, 0o750); err != nil {
 		return nil, err
 	}
 
@@ -204,7 +204,7 @@ func initConfig() (*db.Config, error) {
 			legacyData, readErr := os.ReadFile(legacyPath) // #nosec G304 -- path is constructed from homeDir + hardcoded strings
 			if readErr != nil {
 				slog.Warn("Failed to read legacy config for migration", "path", legacyPath, "error", readErr)
-			} else if writeErr := os.WriteFile(configPath, legacyData, 0600); writeErr != nil { // #nosec G703 -- path is constructed from homeDir + hardcoded strings
+			} else if writeErr := os.WriteFile(configPath, legacyData, 0o600); writeErr != nil { // #nosec G703 -- path is constructed from homeDir + hardcoded strings
 				slog.Warn("Failed to write migrated config", "from", legacyPath, "to", configPath, "error", writeErr)
 			} else {
 				slog.Info("Migrated config from legacy path", "from", legacyPath, "to", configPath)


### PR DESCRIPTION
## Description

This PR updates the connection related methods and functions to make use of types.Connection as a param object, in order to make further updates easier.

Full list of changes:
- Updates methods and function signatures related to connections to use a parameter object in the following places
  - internal/cmd/commands.go
  - internal/db/config.go
  - internal/redis/connection.go
- Updates the corresponding command func/methods to also use the param object.
- Updates the `internal/redis/connection.go` Connect method to handle TLS Config and Connections, since we have the full Connection.
  - This removes the need for the `ConnectWithTLS` method, and its related commands `AutoConnect`
- Adds a new Model method `convertCurrentInputsToConnection` which converts the current Add/Edit inputs into a Connection
- Add tests for new method
- Adds command to MakeFile `debug-server` which stands up a headless `dlv` server, ready to start the application once a debugger is connected

Fixes #20 

## Type of Change

- [x] Refactor

## Checklist

- [x] My code follows the style guidelines of this project (Please double check me here)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes