### PR TITLE
Feature/connection username option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ go install github.com/davidbudnick/redis-tui@latest
 
 ### Connections and Security
 
-- **CLI quick connect** — pass `--host`, `--port`, `--username`, `--password`, etc. to connect without a config file
+- **CLI quick connect** — pass `--host`, `--port`, `--user`, `--password`, etc. to connect without a config file
 - **Connection manager** — save and switch between multiple Redis instances
 - **TLS/SSL** encryption support
 - **SSH tunneling** for secure remote access
@@ -151,7 +151,7 @@ Press `?` inside the app to view the full help screen.
 | `--port`            | `-p`  | Redis server port                                   | 6379        |
 | `--password`        | `-a`  | Redis password                                      |             |
 | `--db`              | `-n`  | Database number (0-15)                              | 0           |
-| `--user`            |       | Redis username (For ACL enabled servers)            | default     |
+| `--user`            |       | Redis username (For ACL enabled servers)            |             |
 | `--name`            |       | Connection display name                             | `host:port` |
 | `--cluster`         |       | Enable cluster mode                                 | false       |
 | `--tls`             |       | Enable TLS/SSL                                      | false       |
@@ -410,6 +410,7 @@ Configuration is stored in `~/.config/redis-tui/config.json`.
 | `port`                            | Redis server port (default: 6379)           |
 | `password`                        | Redis password (never saved to disk)        |
 | `db`                              | Redis database number (0-15)                |
+| `username`                        | Redis ACL username (optional)               |
 | `group`                           | Connection group name (optional)            |
 | `color`                           | Display color for the connection (optional) |
 | `use_tls`                         | Enable TLS/SSL connection                   |

--- a/README.md
+++ b/README.md
@@ -26,15 +26,19 @@ go install github.com/davidbudnick/redis-tui@latest
 > **Pre-built binaries** — [Download from GitHub Releases](https://github.com/davidbudnick/redis-tui/releases)
 
 ## Screenshots
+
 ### Key Browser with Preview
+
 ![Main](docs/main.png)
 
 ### Live Metrics Dashboard
+
 ![Metrics](docs/metrics.png)
 
 ## Features
 
 ### Browsing and Editing
+
 - **Key browser** with pattern filtering, regex, and fuzzy search
 - **All data types** — strings, lists, sets, sorted sets, hashes, streams, JSON (RedisJSON), HyperLogLog, bitmaps, and geospatial
 - **Inline editing** with VIM keybindings for strings and collections
@@ -45,7 +49,8 @@ go install github.com/davidbudnick/redis-tui@latest
 - **JSON syntax highlighting**
 
 ### Connections and Security
-- **CLI quick connect** — pass `--host`, `--port`, `--password`, etc. to connect without a config file
+
+- **CLI quick connect** — pass `--host`, `--port`, `--username`, `--password`, etc. to connect without a config file
 - **Connection manager** — save and switch between multiple Redis instances
 - **TLS/SSL** encryption support
 - **SSH tunneling** for secure remote access
@@ -54,6 +59,7 @@ go install github.com/davidbudnick/redis-tui@latest
 - **Cluster support** — connect to any cluster node and press `K` to view all nodes, their roles (master/replica), slot ranges, and link state; cluster metrics in the live dashboard
 
 ### Monitoring and Operations
+
 - **Live metrics dashboard** — real-time ops/sec, memory, CPU, network I/O, hit rate, and client count with scrolling ASCII charts; cluster node count display
 - **Server info** — version, mode, OS, uptime, memory, and connected clients
 - **Memory stats** — detailed usage breakdown and top keys by memory consumption
@@ -139,23 +145,24 @@ Press `?` inside the app to view the full help screen.
 
 ### CLI Flags
 
-| Flag | Short | Description | Default |
-| --- | --- | --- | --- |
-| `--host` | `-h` | Redis server hostname | |
-| `--port` | `-p` | Redis server port | 6379 |
-| `--password` | `-a` | Redis password | |
-| `--db` | `-n` | Database number (0-15) | 0 |
-| `--name` | | Connection display name | `host:port` |
-| `--cluster` | | Enable cluster mode | false |
-| `--tls` | | Enable TLS/SSL | false |
-| `--tls-cert` | | TLS client certificate file | |
-| `--tls-key` | | TLS client private key file | |
-| `--tls-ca` | | TLS CA certificate file | |
-| `--tls-skip-verify` | | Skip TLS certificate verification | false |
-| `--scan-size` | | Redis SCAN COUNT hint (batch size for key scanning) | 1000 |
-| `--include-types` | | Fetch key types during scan (set false to skip) | true |
-| `--version` | | Print version and exit | |
-| `--update` | | Update to the latest version | |
+| Flag                | Short | Description                                         | Default     |
+| ------------------- | ----- | --------------------------------------------------- | ----------- |
+| `--host`            | `-h`  | Redis server hostname                               |             |
+| `--port`            | `-p`  | Redis server port                                   | 6379        |
+| `--password`        | `-a`  | Redis password                                      |             |
+| `--db`              | `-n`  | Database number (0-15)                              | 0           |
+| `--user`            |       | Redis username (For ACL enabled servers)            | default     |
+| `--name`            |       | Connection display name                             | `host:port` |
+| `--cluster`         |       | Enable cluster mode                                 | false       |
+| `--tls`             |       | Enable TLS/SSL                                      | false       |
+| `--tls-cert`        |       | TLS client certificate file                         |             |
+| `--tls-key`         |       | TLS client private key file                         |             |
+| `--tls-ca`          |       | TLS CA certificate file                             |             |
+| `--tls-skip-verify` |       | Skip TLS certificate verification                   | false       |
+| `--scan-size`       |       | Redis SCAN COUNT hint (batch size for key scanning) | 1000        |
+| `--include-types`   |       | Fetch key types during scan (set false to skip)     | true        |
+| `--version`         |       | Print version and exit                              |             |
+| `--update`          |       | Update to the latest version                        |             |
 
 Short flags (`-h`, `-p`, `-a`, `-n`) follow [redis-cli](https://redis.io/docs/latest/develop/connect/cli/) conventions.
 
@@ -177,55 +184,55 @@ rm -f $(go env GOPATH)/bin/redis-tui
 
 ### Global
 
-| Key | Action | Key | Action |
-| --- | --- | --- | --- |
-| `q` | Quit / Go back | `Ctrl+U/D` | Page up/down |
-| `?` | Show help | `g/G` | Go to top/bottom |
-| `j/k` | Navigate up/down | `home/end` | Go to top/bottom |
-| `Ctrl+C` | Force quit | | |
+| Key      | Action           | Key        | Action           |
+| -------- | ---------------- | ---------- | ---------------- |
+| `q`      | Quit / Go back   | `Ctrl+U/D` | Page up/down     |
+| `?`      | Show help        | `g/G`      | Go to top/bottom |
+| `j/k`    | Navigate up/down | `home/end` | Go to top/bottom |
+| `Ctrl+C` | Force quit       |            |                  |
 
 ### Connections Screen
 
-| Key | Action | Key | Action |
-| --- | --- | --- | --- |
+| Key     | Action              | Key                  | Action            |
+| ------- | ------------------- | -------------------- | ----------------- |
 | `Enter` | Connect to selected | `d/delete/backspace` | Delete connection |
-| `a/n` | Add new connection | `r` | Refresh list |
-| `e` | Edit connection | `Ctrl+T` | Test connection |
+| `a/n`   | Add new connection  | `r`                  | Refresh list      |
+| `e`     | Edit connection     | `Ctrl+T`             | Test connection   |
 
 ### Keys Screen
 
-| Key | Action | Key | Action |
-| --- | --- | --- | --- |
-| `Enter` | View key details | `O` | View logs |
-| `a/n` | Add new key | `B` | Bulk delete |
-| `d/delete/backspace` | Delete key | `T` | Batch set TTL |
-| `r` | Refresh keys | `F` | View favorites |
-| `l` | Load more keys | `W` | Tree view |
-| `/` | Filter by pattern | `Ctrl+R` | Regex search |
-| `s/S` | Sort / Toggle direction | `Ctrl+F` | Fuzzy search |
-| `v` | Search by value | `Ctrl+H` | Recent keys |
-| `e` | Export to JSON | `Ctrl+L` | Client list |
-| `I` | Import from JSON | `Ctrl+E` | Toggle keyspace events |
-| `i` | Server info | `Ctrl+X` | View expiring keys |
-| `D` | Switch database | `m` | Live metrics dashboard |
-| `f` | Flush database | `M` | Memory stats |
-| `p` | Pub/Sub channels | `K` | Cluster info |
-| `L` | View slow log | `=` | Compare keys |
-| `E` | Execute Lua script | `P` | Key templates |
-| `Ctrl+G` | Redis config | | |
+| Key                  | Action                  | Key      | Action                 |
+| -------------------- | ----------------------- | -------- | ---------------------- |
+| `Enter`              | View key details        | `O`      | View logs              |
+| `a/n`                | Add new key             | `B`      | Bulk delete            |
+| `d/delete/backspace` | Delete key              | `T`      | Batch set TTL          |
+| `r`                  | Refresh keys            | `F`      | View favorites         |
+| `l`                  | Load more keys          | `W`      | Tree view              |
+| `/`                  | Filter by pattern       | `Ctrl+R` | Regex search           |
+| `s/S`                | Sort / Toggle direction | `Ctrl+F` | Fuzzy search           |
+| `v`                  | Search by value         | `Ctrl+H` | Recent keys            |
+| `e`                  | Export to JSON          | `Ctrl+L` | Client list            |
+| `I`                  | Import from JSON        | `Ctrl+E` | Toggle keyspace events |
+| `i`                  | Server info             | `Ctrl+X` | View expiring keys     |
+| `D`                  | Switch database         | `m`      | Live metrics dashboard |
+| `f`                  | Flush database          | `M`      | Memory stats           |
+| `p`                  | Pub/Sub channels        | `K`      | Cluster info           |
+| `L`                  | View slow log           | `=`      | Compare keys           |
+| `E`                  | Execute Lua script      | `P`      | Key templates          |
+| `Ctrl+G`             | Redis config            |          |                        |
 
 ### Key Detail Screen
 
-| Key | Action | Key | Action |
-| --- | --- | --- | --- |
-| `e` | Edit value (string/json) | `r` | Refresh value |
-| `a` | Add to collection | `f` | Toggle favorite |
-| `x` | Remove from collection | `w` | Watch for changes |
-| `t` | Set TTL | `h` | View value history |
-| `R` | Rename key | `y` | Copy to clipboard |
-| `c` | Copy key | `J` | JSON path query |
-| `d/delete` | Delete key | `j/k` | Navigate collection items |
-| `esc/backspace` | Go back to keys list | | |
+| Key             | Action                   | Key   | Action                    |
+| --------------- | ------------------------ | ----- | ------------------------- |
+| `e`             | Edit value (string/json) | `r`   | Refresh value             |
+| `a`             | Add to collection        | `f`   | Toggle favorite           |
+| `x`             | Remove from collection   | `w`   | Watch for changes         |
+| `t`             | Set TTL                  | `h`   | View value history        |
+| `R`             | Rename key               | `y`   | Copy to clipboard         |
+| `c`             | Copy key                 | `J`   | JSON path query           |
+| `d/delete`      | Delete key               | `j/k` | Navigate collection items |
+| `esc/backspace` | Go back to keys list     |       |                           |
 
 </details>
 
@@ -257,6 +264,7 @@ Configuration is stored in `~/.config/redis-tui/config.json`.
       "name": "Standalone",
       "host": "localhost",
       "port": 6379,
+      "username": "default",
       "db": 0,
       "created_at": "2025-01-01T00:00:00Z",
       "updated_at": "2025-01-01T00:00:00Z"
@@ -395,27 +403,27 @@ Configuration is stored in `~/.config/redis-tui/config.json`.
 
 ### Connection Options
 
-| Option | Description |
-| --- | --- |
-| `name` | Display name for the connection |
-| `host` | Redis server hostname or IP |
-| `port` | Redis server port (default: 6379) |
-| `password` | Redis password (never saved to disk) |
-| `db` | Redis database number (0-15) |
-| `group` | Connection group name (optional) |
-| `color` | Display color for the connection (optional) |
-| `use_tls` | Enable TLS/SSL connection |
-| `tls_config.cert_file` | Client certificate file path |
-| `tls_config.key_file` | Client key file path |
-| `tls_config.ca_file` | CA certificate file path |
-| `tls_config.insecure_skip_verify` | Skip TLS certificate verification |
-| `tls_config.server_name` | TLS server name for verification |
-| `use_ssh` | Enable SSH tunneling |
-| `ssh_config.host` | SSH server hostname |
-| `ssh_config.port` | SSH server port |
-| `ssh_config.user` | SSH username |
-| `ssh_config.private_key_path` | Path to SSH private key file |
-| `use_cluster` | Enable Redis cluster mode |
+| Option                            | Description                                 |
+| --------------------------------- | ------------------------------------------- |
+| `name`                            | Display name for the connection             |
+| `host`                            | Redis server hostname or IP                 |
+| `port`                            | Redis server port (default: 6379)           |
+| `password`                        | Redis password (never saved to disk)        |
+| `db`                              | Redis database number (0-15)                |
+| `group`                           | Connection group name (optional)            |
+| `color`                           | Display color for the connection (optional) |
+| `use_tls`                         | Enable TLS/SSL connection                   |
+| `tls_config.cert_file`            | Client certificate file path                |
+| `tls_config.key_file`             | Client key file path                        |
+| `tls_config.ca_file`              | CA certificate file path                    |
+| `tls_config.insecure_skip_verify` | Skip TLS certificate verification           |
+| `tls_config.server_name`          | TLS server name for verification            |
+| `use_ssh`                         | Enable SSH tunneling                        |
+| `ssh_config.host`                 | SSH server hostname                         |
+| `ssh_config.port`                 | SSH server port                             |
+| `ssh_config.user`                 | SSH username                                |
+| `ssh_config.private_key_path`     | Path to SSH private key file                |
+| `use_cluster`                     | Enable Redis cluster mode                   |
 
 ### Custom Keybindings
 

--- a/internal/cmd/commands_connection_test.go
+++ b/internal/cmd/commands_connection_test.go
@@ -89,13 +89,28 @@ func TestAddConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cfg := testutil.NewTestConfig(t)
 		cmds := NewCommands(cfg, nil)
-		msg := cmds.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
+		msg := cmds.AddConnection(types.Connection{Name: "test", Host: "localhost", Username: "default", Password: "password", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionAddedMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
 		}
 		if result.Connection.Name != "test" {
 			t.Errorf("Name = %q, want %q", result.Connection.Name, "test")
+		}
+		if result.Connection.Host != "localhost" {
+			t.Errorf("Host = %q, want %q", result.Connection.Host, "localhost")
+		}
+		if result.Connection.Port != 6379 {
+			t.Errorf("Port = %d, want %d", result.Connection.Port, 6379)
+		}
+		if result.Connection.Username != "default" {
+			t.Errorf("Username = %q, want %q", result.Connection.Username, "default")
+		}
+		if result.Connection.Password != "password" {
+			t.Errorf("Password = %q, want %q", result.Connection.Password, "password")
+		}
+		if result.Connection.DB != 0 {
+			t.Errorf("DB = %d, want %d", result.Connection.DB, 0)
 		}
 	})
 
@@ -112,15 +127,30 @@ func TestAddConnection(t *testing.T) {
 func TestUpdateConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cfg := testutil.NewTestConfig(t)
-		conn := testutil.MustAddConnection(t, cfg, types.Connection{Name: "old", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})
+		conn := testutil.MustAddConnection(t, cfg, types.Connection{Name: "old", Host: "localhost", Username: "default", Password: "newpass", Port: 6379, DB: 0, UseCluster: false})
 		cmds := NewCommands(cfg, nil)
-		msg := cmds.UpdateConnection(types.Connection{ID: conn.ID, Name: "new", Host: "localhost", Port: 6380, Password: "pass", DB: 1, UseCluster: false})()
+		msg := cmds.UpdateConnection(types.Connection{ID: conn.ID, Name: "new", Host: "localhost", Port: 6380, Username: "newuser", Password: "pass", DB: 1, UseCluster: false})()
 		result := msg.(types.ConnectionUpdatedMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
 		}
 		if result.Connection.Name != "new" {
 			t.Errorf("Name = %q, want %q", result.Connection.Name, "new")
+		}
+		if result.Connection.Host != "localhost" {
+			t.Errorf("Host = %q, want %q", result.Connection.Host, "localhost")
+		}
+		if result.Connection.Port != 6380 {
+			t.Errorf("Port = %d, want %d", result.Connection.Port, 6380)
+		}
+		if result.Connection.Username != "newuser" {
+			t.Errorf("Username = %q, want %q", result.Connection.Username, "newuser")
+		}
+		if result.Connection.Password != "pass" {
+			t.Errorf("Password = %q, want %q", result.Connection.Password, "pass")
+		}
+		if result.Connection.DB != 1 {
+			t.Errorf("DB = %d, want %d", result.Connection.DB, 1)
 		}
 	})
 
@@ -162,7 +192,7 @@ func TestDeleteConnection(t *testing.T) {
 func TestConnect(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, _ := newMockCmds()
-		msg := cmds.Connect(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
+		msg := cmds.Connect(types.Connection{Name: "test", Host: "localhost", Username: "default", Password: "password", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectedMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)
@@ -220,7 +250,7 @@ func TestTestConnection(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cmds, mock := newMockCmds()
 		mock.TestConnectionLatency = 5 * time.Millisecond
-		msg := cmds.TestConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, DB: 0, UseCluster: false})()
+		msg := cmds.TestConnection(types.Connection{Name: "test", Host: "localhost", Username: "default", Password: "password", Port: 6379, DB: 0, UseCluster: false})()
 		result := msg.(types.ConnectionTestMsg)
 		if result.Err != nil {
 			t.Errorf("unexpected error: %v", result.Err)

--- a/internal/db/config.go
+++ b/internal/db/config.go
@@ -210,6 +210,7 @@ func (c *Config) UpdateConnection(conn types.Connection) (types.Connection, erro
 				Name:       conn.Name,
 				Host:       conn.Host,
 				Port:       conn.Port,
+				Username:   conn.Username,
 				Password:   conn.Password,
 				DB:         conn.DB,
 				Group:      toUpdateConn.Group,

--- a/internal/db/config_integrity_test.go
+++ b/internal/db/config_integrity_test.go
@@ -18,7 +18,7 @@ func TestConfig_Integration_FullConnectionLifecycle(t *testing.T) {
 	cfg := newTestConfig(t)
 
 	// Step 1: Add a connection with all features
-	conn, err := cfg.AddConnection(types.Connection{Name: "prod", Host: "redis.example.com", Port: 6380, DB: 2, UseCluster: true})
+	conn, err := cfg.AddConnection(types.Connection{Name: "prod", Host: "redis.example.com", Username: "default", Password: "secret", Port: 6380, DB: 2, UseCluster: true})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestConfig_Integration_FullConnectionLifecycle(t *testing.T) {
 		t.Fatalf("expected 1 connection after first reload, got %d", len(connections))
 	}
 	got := connections[0]
-	if got.Name != "prod" || got.Host != "redis.example.com" || got.Port != 6380 || got.DB != 2 || !got.UseCluster {
+	if got.Name != "prod" || got.Host != "redis.example.com" || got.Port != 6380 || got.Username != "default" || got.DB != 2 || !got.UseCluster {
 		t.Errorf("basic fields corrupted after reload: %+v", got)
 	}
 	if !got.UseSSH || got.SSHConfig == nil || got.SSHConfig.Host != "bastion.example.com" {
@@ -104,6 +104,7 @@ func TestConfig_Integration_FullConnectionLifecycle(t *testing.T) {
 	got.Name = "prod-updated"
 	got.Host = "redis2.example.com"
 	got.Port = 6381
+	got.Username = "admin"
 	got.DB = 3
 	got.UseCluster = false
 	updated, err := cfg2.UpdateConnection(got)
@@ -112,6 +113,21 @@ func TestConfig_Integration_FullConnectionLifecycle(t *testing.T) {
 	}
 	if updated.Name != "prod-updated" {
 		t.Errorf("Name not updated: %q", updated.Name)
+	}
+	if updated.Host != "redis2.example.com" {
+		t.Errorf("Host not updated: %q", updated.Host)
+	}
+	if updated.Port != 6381 {
+		t.Errorf("Port not updated: %d", updated.Port)
+	}
+	if updated.Username != "admin" {
+		t.Errorf("Username not updated: %q", updated.Username)
+	}
+	if updated.DB != 3 {
+		t.Errorf("DB not updated: %d", updated.DB)
+	}
+	if updated.UseCluster {
+		t.Error("UseCluster should have been updated to false")
 	}
 	if !updated.UseSSH || updated.SSHConfig == nil {
 		t.Error("SSH config lost after update")
@@ -126,7 +142,7 @@ func TestConfig_Integration_FullConnectionLifecycle(t *testing.T) {
 	if errList3 != nil {
 		t.Fatalf("ListConnections failed: %v", errList3)
 	}
-	if connections3[0].Name != "prod-updated" || connections3[0].Host != "redis2.example.com" {
+	if connections3[0].Name != "prod-updated" || connections3[0].Host != "redis2.example.com" || connections3[0].Port != 6381 || connections3[0].Username != "admin" || connections3[0].DB != 3 || connections3[0].UseCluster {
 		t.Error("update not persisted after reload")
 	}
 	if !connections3[0].UseSSH || !connections3[0].UseTLS {

--- a/internal/db/config_persistence_test.go
+++ b/internal/db/config_persistence_test.go
@@ -14,7 +14,7 @@ import (
 func TestConfig_Persistence_AllConnectionFields(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection(types.Connection{Name: "prod-redis", Host: "redis.example.com", Port: 6380, DB: 2, UseCluster: true})
+	conn, err := cfg.AddConnection(types.Connection{Name: "prod-redis", Host: "redis.example.com", Username: "default", Port: 6380, DB: 2, UseCluster: true})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -40,6 +40,9 @@ func TestConfig_Persistence_AllConnectionFields(t *testing.T) {
 	}
 	if got.Port != 6380 {
 		t.Errorf("Port = %d, want %d", got.Port, 6380)
+	}
+	if got.Username != "default" {
+		t.Errorf("Username = %q, want %q", got.Username, "default")
 	}
 	if got.DB != 2 {
 		t.Errorf("DB = %d, want %d", got.DB, 2)

--- a/internal/db/config_test.go
+++ b/internal/db/config_test.go
@@ -54,7 +54,7 @@ func TestNewConfig_CreatesDirectory(t *testing.T) {
 func TestConfig_AddConnection(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, Password: "secret", DB: 0, UseCluster: false})
+	conn, err := cfg.AddConnection(types.Connection{Name: "test", Host: "localhost", Port: 6379, Username: "default", Password: "secret", DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -70,6 +70,9 @@ func TestConfig_AddConnection(t *testing.T) {
 	}
 	if conn.Port != 6379 {
 		t.Errorf("Port = %d, want 6379", conn.Port)
+	}
+	if conn.Username != "default" {
+		t.Errorf("Username = %q, want \"default\"", conn.Username)
 	}
 	if conn.Password != "secret" {
 		t.Errorf("Password = %q, want \"secret\"", conn.Password)
@@ -147,7 +150,7 @@ func TestConfig_ListConnections(t *testing.T) {
 func TestConfig_UpdateConnection(t *testing.T) {
 	cfg := newTestConfig(t)
 
-	conn, err := cfg.AddConnection(types.Connection{Name: "original", Host: "localhost", Port: 6379, Password: "old", DB: 0, UseCluster: false})
+	conn, err := cfg.AddConnection(types.Connection{Name: "original", Host: "localhost", Port: 6379, Username: "default", Password: "old", DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("AddConnection failed: %v", err)
 	}
@@ -155,6 +158,7 @@ func TestConfig_UpdateConnection(t *testing.T) {
 	conn.Name = "updated"
 	conn.Host = "newhost"
 	conn.Port = 6380
+	conn.Username = "newuser"
 	conn.Password = "new"
 	conn.DB = 1
 
@@ -171,6 +175,9 @@ func TestConfig_UpdateConnection(t *testing.T) {
 	}
 	if updated.Port != 6380 {
 		t.Errorf("Port = %d, want 6380", updated.Port)
+	}
+	if updated.Username != "newuser" {
+		t.Errorf("Username = %q, want \"newuser\"", updated.Username)
 	}
 	if updated.Password != "new" {
 		t.Errorf("Password = %q, want \"new\"", updated.Password)

--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -29,6 +29,7 @@ type Client struct {
 
 	host     string
 	port     int
+	username string
 	password string
 	db       int
 

--- a/internal/redis/connection.go
+++ b/internal/redis/connection.go
@@ -33,6 +33,7 @@ func defaultOptions(conn types.Connection) (*redis.Options, error) {
 
 	return &redis.Options{
 		Addr:         fmt.Sprintf("%s:%d", conn.Host, conn.Port),
+		Username:     conn.Username,
 		Password:     conn.Password,
 		DB:           conn.DB,
 		DialTimeout:  defaultDialTimeout,
@@ -75,6 +76,7 @@ func (c *Client) Connect(conn types.Connection) error {
 	c.mu.Lock()
 	c.host = conn.Host
 	c.port = conn.Port
+	c.username = conn.Username
 	c.password = conn.Password
 	c.db = conn.DB
 	c.client = client
@@ -103,6 +105,7 @@ func (c *Client) ConnectCluster(addrs []string, conn types.Connection) error {
 
 	opts := &redis.ClusterOptions{
 		Addrs:        addrs,
+		Username:     conn.Username,
 		Password:     conn.Password,
 		DialTimeout:  defaultDialTimeout,
 		ReadTimeout:  defaultReadTimeout,
@@ -138,6 +141,7 @@ func (c *Client) ConnectCluster(addrs []string, conn types.Connection) error {
 
 	c.mu.Lock()
 	c.isCluster = true
+	c.username = conn.Username
 	c.password = conn.Password
 	c.host = host
 	c.port = port

--- a/internal/redis/connection_test.go
+++ b/internal/redis/connection_test.go
@@ -55,7 +55,7 @@ func TestConnect(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	if err := client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "", DB: 0, UseCluster: false}); err != nil {
+	if err := client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Username: "default", Password: "", DB: 0, UseCluster: false}); err != nil {
 		t.Fatalf("Connect() returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
@@ -82,10 +82,28 @@ func TestConnect_WrongPassword(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	err = client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "wrong-password", DB: 0, UseCluster: false})
+	err = client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Username: "default", Password: "wrong-password", DB: 0, UseCluster: false})
 	if err == nil {
 		_ = client.Disconnect()
 		t.Fatal("expected error when connecting with wrong password")
+	}
+}
+
+func TestConnect_WrongUsernamePassword(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	mr.RequireUserAuth("testuser", "correct-password")
+
+	client := NewClient()
+	port, _ := strconv.Atoi(mr.Port())
+
+	err = client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Username: "wrong-user", Password: "wrong-password", DB: 0, UseCluster: false})
+	if err == nil {
+		_ = client.Disconnect()
+		t.Fatal("expected error when connecting with wrong username and password")
 	}
 }
 
@@ -134,9 +152,27 @@ func TestConnect_CorrectPassword(t *testing.T) {
 	client := NewClient()
 	port, _ := strconv.Atoi(mr.Port())
 
-	err = client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Password: "correct-password", DB: 0, UseCluster: false})
+	err = client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Username: "default", Password: "correct-password", DB: 0, UseCluster: false})
 	if err != nil {
 		t.Fatalf("Connect() with correct password returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Disconnect() })
+}
+
+func TestConnect_CorrectUserPassword(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	mr.RequireUserAuth("testuser", "correct-password")
+
+	client := NewClient()
+	port, _ := strconv.Atoi(mr.Port())
+
+	err = client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Username: "testuser", Password: "correct-password", DB: 0, UseCluster: false})
+	if err != nil {
+		t.Fatalf("Connect() with correct username/password returned error: %v", err)
 	}
 	t.Cleanup(func() { _ = client.Disconnect() })
 }

--- a/internal/redis/server_test.go
+++ b/internal/redis/server_test.go
@@ -252,6 +252,36 @@ func TestTestConnection(t *testing.T) {
 		}
 	})
 
+	t.Run("successful connection with username / password returns latency", func(t *testing.T) {
+		client, mr := setupTestClientWithAuth(t, "testuser", "testpass")
+
+		port, err := strconv.Atoi(mr.Port())
+		if err != nil {
+			t.Fatalf("failed to parse port: %v", err)
+		}
+
+		latency, err := client.TestConnection(types.Connection{Name: "test", Host: mr.Host(), Port: port, Username: "testuser", Password: "testpass", DB: 0, UseCluster: false})
+		if err != nil {
+			t.Fatalf("TestConnection() error = %v", err)
+		}
+		if latency <= 0 {
+			t.Errorf("TestConnection() latency = %v, want > 0", latency)
+		}
+	})
+
+	t.Run("wrong username / password returns error", func(t *testing.T) {
+		client, mr := setupTestClientWithAuth(t, "testuser", "testpass")
+
+		port, err := strconv.Atoi(mr.Port())
+		if err != nil {
+			t.Fatalf("failed to parse port: %v", err)
+		}
+
+		if _, err := client.TestConnection(types.Connection{Name: "test", Host: mr.Host(), Port: port, Username: "baduser", Password: "badpass", DB: 0, UseCluster: false}); err == nil {
+			t.Fatal("TestConnection() expected error for wrong username/password, got nil")
+		}
+	})
+
 	t.Run("wrong port returns error", func(t *testing.T) {
 		client, _ := setupTestClient(t)
 
@@ -383,29 +413,29 @@ func TestTestConnection(t *testing.T) {
 	})
 
 	t.Run("failed to build TLS config", func(t *testing.T) {
+		client := NewClient()
+
+		conn := types.Connection{
+			Name:   "tls-build-error",
+			Host:   "localhost",
+			Port:   6379,
+			UseTLS: true,
+			TLSConfig: &types.TLSConfig{
+				CertFile: "/path/to/nowhere/cert.pem",
+				KeyFile:  "/path/to/nowhere/key.pem",
+			},
+		}
+
+		_, err := client.TestConnection(conn)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "failed to build TLS config") &&
+			!strings.Contains(err.Error(), "failed to load TLS key pair") {
+			t.Errorf("unexpected error message: %v", err)
+		}
 	})
-	client := NewClient()
-
-	conn := types.Connection{
-		Name:   "tls-build-error",
-		Host:   "localhost",
-		Port:   6379,
-		UseTLS: true,
-		TLSConfig: &types.TLSConfig{
-			CertFile: "/path/to/nowhere/cert.pem",
-			KeyFile:  "/path/to/nowhere/key.pem",
-		},
-	}
-
-	_, err := client.TestConnection(conn)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
-	if !strings.Contains(err.Error(), "failed to build TLS config") &&
-		!strings.Contains(err.Error(), "failed to load TLS key pair") {
-		t.Errorf("unexpected error message: %v", err)
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/redis/testhelper_test.go
+++ b/internal/redis/testhelper_test.go
@@ -25,3 +25,22 @@ func setupTestClient(t *testing.T) (*Client, *miniredis.Miniredis) {
 
 	return client, mr
 }
+
+func setupTestClientWithAuth(t *testing.T, username string, password string) (*Client, *miniredis.Miniredis) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	mr.RequireUserAuth(username, password)
+
+	client := NewClient()
+	port, _ := strconv.Atoi(mr.Port())
+	if err := client.Connect(types.Connection{Name: "test", Host: mr.Host(), Port: port, Username: username, Password: password, DB: 0, UseCluster: false}); err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	return client, mr
+}

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -14,7 +14,7 @@ type Connection struct {
 	Name       string     `json:"name"`
 	Host       string     `json:"host"`
 	Port       int        `json:"port"`
-	Username   string     `json:"username,omitempty"`
+	Username   string     `json:"username"`
 	Password   string     `json:"password,omitempty"` // #nosec G117 -- stored in local user config.
 	DB         int        `json:"db"`
 	Group      string     `json:"group,omitempty"`

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -14,6 +14,7 @@ type Connection struct {
 	Name       string     `json:"name"`
 	Host       string     `json:"host"`
 	Port       int        `json:"port"`
+	Username   string     `json:"username,omitempty"`
 	Password   string     `json:"password,omitempty"` // #nosec G117 -- stored in local user config.
 	DB         int        `json:"db"`
 	Group      string     `json:"group,omitempty"`

--- a/internal/ui/gaps_test.go
+++ b/internal/ui/gaps_test.go
@@ -71,14 +71,14 @@ func TestHandleRedisConfigScreen_Down(t *testing.T) {
 func TestHandleAddConnectionScreen_ClusterFocusOverflow(t *testing.T) {
 	m, _, _ := newTestModel(t)
 	// Put focus past what cluster mode allows (DB field at idx 5)
-	m.ConnFocusIdx = 5
+	m.ConnFocusIdx = 6
 	m.ConnClusterMode = false
 	// First toggle cluster on at idx 4 scenario: manually create a state where
 	// after toggling, focus idx >= connFieldCount
-	m.ConnFocusIdx = 4
+	m.ConnFocusIdx = 5
 	_, _ = m.handleAddConnectionScreen(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
 	// Now cluster is on — re-toggle with focus still valid
-	m.ConnClusterMode = true // Have to set this manually
+	m.ConnClusterMode = true // m is a val, not a pointer, so we need to manually flip
 	_, _ = m.handleAddConnectionScreen(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
 }
 
@@ -86,10 +86,23 @@ func TestHandleAddConnectionScreen_ClusterFocusOverflow(t *testing.T) {
 
 func TestUpdateConnInputs_ClusterToggleFocus(t *testing.T) {
 	m, _, _ := newTestModel(t)
-	m.ConnFocusIdx = 4 // cluster toggle — no text input
+	m.ConnFocusIdx = 5                   // cluster toggle — no text input
+	m.ConnInputs[m.ConnFocusIdx].Focus() // Needs to be focused for Update to return a cmd
 	_, cmd := m.updateConnInputs(keyMsg('x'))
 	if cmd != nil {
 		t.Error("expected nil cmd when focus on cluster toggle")
+	}
+}
+
+// ---- updateConnInputs returns cmd when focus is not on cluster ----
+
+func TestUpdateConnInputs_NotCluster(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.ConnFocusIdx = 1                   // host input — should return cmd
+	m.ConnInputs[m.ConnFocusIdx].Focus() // Needs to be focused for Update to return a cmd
+	_, cmd := m.updateConnInputs(keyMsg('x'))
+	if cmd == nil {
+		t.Error("expected cmd when focus not on cluster toggle")
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -268,7 +268,8 @@ func createConnectionInputs() []textinput.Model {
 	inputs[3] = textinput.New()
 	inputs[3].Placeholder = "Username (optional)"
 	inputs[3].Width = 30
-	inputs[3].SetValue("6379")
+	inputs[3].SetValue("default")
+
 	inputs[4] = textinput.New()
 	inputs[4].Placeholder = "Password (optional)"
 	inputs[4].Width = 30
@@ -356,7 +357,7 @@ func (m Model) getPort() int {
 }
 
 func (m Model) getDB() int {
-	db, err := strconv.Atoi(m.ConnInputs[4].Value())
+	db, err := strconv.Atoi(m.ConnInputs[5].Value())
 	if err != nil {
 		return 0
 	}
@@ -420,8 +421,8 @@ func (m *Model) convertCurrentInputsToConnection(inputs []textinput.Model, actio
 }
 
 // connFieldCount returns the number of focusable fields in the connection form.
-// When cluster mode is on, the DB field is skipped (5 fields: name, host, port, password, cluster toggle).
-// Otherwise there are 6 fields: name, host, port, password, cluster toggle, database.
+// When cluster mode is on, the DB field is skipped (6 fields: name, host, port, username, password, cluster toggle).
+// Otherwise there are 7 fields: name, host, port, username, password, cluster toggle, database.
 func (m Model) connFieldCount() int {
 	if m.ConnClusterMode {
 		return 6

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -248,7 +248,7 @@ func createTextInput(placeholder string, width int) textinput.Model {
 }
 
 func createConnectionInputs() []textinput.Model {
-	inputs := make([]textinput.Model, 5)
+	inputs := make([]textinput.Model, 6)
 
 	inputs[0] = textinput.New()
 	inputs[0].Placeholder = "Connection Name"
@@ -266,14 +266,18 @@ func createConnectionInputs() []textinput.Model {
 	inputs[2].SetValue("6379")
 
 	inputs[3] = textinput.New()
-	inputs[3].Placeholder = "Password (optional)"
+	inputs[3].Placeholder = "Username (optional)"
 	inputs[3].Width = 30
-	inputs[3].EchoMode = textinput.EchoPassword
-
+	inputs[3].SetValue("6379")
 	inputs[4] = textinput.New()
-	inputs[4].Placeholder = "Database (0-15)"
+	inputs[4].Placeholder = "Password (optional)"
 	inputs[4].Width = 30
-	inputs[4].SetValue("0")
+	inputs[4].EchoMode = textinput.EchoPassword
+
+	inputs[5] = textinput.New()
+	inputs[5].Placeholder = "Database (0-15)"
+	inputs[5].Width = 30
+	inputs[5].SetValue("0")
 
 	return inputs
 }
@@ -366,7 +370,7 @@ func (m *Model) resetConnInputs() {
 	}
 	m.ConnInputs[1].SetValue("localhost")
 	m.ConnInputs[2].SetValue("6379")
-	m.ConnInputs[4].SetValue("0")
+	m.ConnInputs[5].SetValue("0")
 	m.ConnInputs[0].Focus()
 	m.ConnFocusIdx = 0
 	m.ConnClusterMode = false
@@ -388,8 +392,9 @@ func (m *Model) populateConnInputs(conn types.Connection) {
 	m.ConnInputs[0].SetValue(conn.Name)
 	m.ConnInputs[1].SetValue(conn.Host)
 	m.ConnInputs[2].SetValue(strconv.Itoa(conn.Port))
-	m.ConnInputs[3].SetValue(conn.Password)
-	m.ConnInputs[4].SetValue(strconv.Itoa(conn.DB))
+	m.ConnInputs[3].SetValue(conn.Username)
+	m.ConnInputs[4].SetValue(conn.Password)
+	m.ConnInputs[5].SetValue(strconv.Itoa(conn.DB))
 	m.ConnClusterMode = conn.UseCluster
 }
 
@@ -401,13 +406,14 @@ func (m *Model) convertCurrentInputsToConnection(inputs []textinput.Model, actio
 	}
 
 	port, _ := strconv.Atoi(inputs[2].Value())
-	db, _ := strconv.Atoi(inputs[4].Value())
+	db, _ := strconv.Atoi(inputs[5].Value())
 	return types.Connection{
 		ID:         id,
 		Name:       inputs[0].Value(),
 		Port:       port,
 		Host:       inputs[1].Value(),
-		Password:   inputs[3].Value(),
+		Username:   inputs[3].Value(),
+		Password:   inputs[4].Value(),
 		DB:         db,
 		UseCluster: m.ConnClusterMode,
 	}
@@ -418,9 +424,9 @@ func (m *Model) convertCurrentInputsToConnection(inputs []textinput.Model, actio
 // Otherwise there are 6 fields: name, host, port, password, cluster toggle, database.
 func (m Model) connFieldCount() int {
 	if m.ConnClusterMode {
-		return 5
+		return 6
 	}
-	return 6
+	return 7
 }
 
 func (m *Model) resetAddCollectionInputs() {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -359,10 +359,12 @@ func TestModel_CLIConnection_Nil(t *testing.T) {
 func TestModel_HandleAutoConnectMsg(t *testing.T) {
 	m := NewModel()
 	conn := types.Connection{
-		Name: "test",
-		Host: "redis.example.com",
-		Port: 6380,
-		DB:   2,
+		Name:     "test",
+		Host:     "redis.example.com",
+		Port:     6380,
+		Username: "default",
+		Password: "password",
+		DB:       2,
 	}
 	msg := types.AutoConnectMsg{Connection: conn}
 
@@ -377,6 +379,12 @@ func TestModel_HandleAutoConnectMsg(t *testing.T) {
 	}
 	if model.CurrentConn.Port != 6380 {
 		t.Errorf("Port = %d, want %d", model.CurrentConn.Port, 6380)
+	}
+	if model.CurrentConn.Username != "default" {
+		t.Errorf("Username = %q, want %q", model.CurrentConn.Username, "default")
+	}
+	if model.CurrentConn.Password != "password" {
+		t.Errorf("Password = %q, want %q", model.CurrentConn.Password, "password")
 	}
 	if model.CurrentConn.DB != 2 {
 		t.Errorf("DB = %d, want %d", model.CurrentConn.DB, 2)

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -15,8 +15,8 @@ func TestNewModel(t *testing.T) {
 	}
 
 	// Check inputs are initialized
-	if len(m.ConnInputs) != 5 {
-		t.Errorf("ConnInputs length = %d, want 5", len(m.ConnInputs))
+	if len(m.ConnInputs) != 6 {
+		t.Errorf("ConnInputs length = %d, want 6", len(m.ConnInputs))
 	}
 
 	if len(m.AddKeyInputs) != 3 {
@@ -40,8 +40,8 @@ func TestNewModel(t *testing.T) {
 		t.Errorf("Port default = %q, want \"6379\"", m.ConnInputs[2].Value())
 	}
 
-	if m.ConnInputs[4].Value() != "0" {
-		t.Errorf("DB default = %q, want \"0\"", m.ConnInputs[4].Value())
+	if m.ConnInputs[5].Value() != "0" {
+		t.Errorf("DB default = %q, want \"0\"", m.ConnInputs[5].Value())
 	}
 
 	// Check TreeExpanded map is initialized
@@ -124,8 +124,9 @@ func TestModel_ResetConnInputs(t *testing.T) {
 	m.ConnInputs[0].SetValue("My Connection")
 	m.ConnInputs[1].SetValue("redis.example.com")
 	m.ConnInputs[2].SetValue("6380")
-	m.ConnInputs[3].SetValue("secret")
-	m.ConnInputs[4].SetValue("5")
+	m.ConnInputs[3].SetValue("user")
+	m.ConnInputs[4].SetValue("secret")
+	m.ConnInputs[5].SetValue("5")
 	m.ConnFocusIdx = 3
 
 	// Reset
@@ -142,10 +143,13 @@ func TestModel_ResetConnInputs(t *testing.T) {
 		t.Errorf("Port = %q, want \"6379\"", m.ConnInputs[2].Value())
 	}
 	if m.ConnInputs[3].Value() != "" {
-		t.Errorf("Password should be empty, got %q", m.ConnInputs[3].Value())
+		t.Errorf("Username should be empty, got %q", m.ConnInputs[3].Value())
 	}
-	if m.ConnInputs[4].Value() != "0" {
-		t.Errorf("DB = %q, want \"0\"", m.ConnInputs[4].Value())
+	if m.ConnInputs[4].Value() != "" {
+		t.Errorf("Password should be empty, got %q", m.ConnInputs[4].Value())
+	}
+	if m.ConnInputs[5].Value() != "0" {
+		t.Errorf("DB = %q, want \"0\"", m.ConnInputs[5].Value())
 	}
 	if m.ConnFocusIdx != 0 {
 		t.Errorf("ConnFocusIdx = %d, want 0", m.ConnFocusIdx)
@@ -190,6 +194,7 @@ func TestModel_PopulateConnInputs(t *testing.T) {
 		Name:     "Production",
 		Host:     "redis.prod.com",
 		Port:     6380,
+		Username: "default",
 		Password: "supersecret",
 		DB:       2,
 	}
@@ -205,11 +210,14 @@ func TestModel_PopulateConnInputs(t *testing.T) {
 	if m.ConnInputs[2].Value() != "6380" {
 		t.Errorf("Port = %q, want \"6380\"", m.ConnInputs[2].Value())
 	}
-	if m.ConnInputs[3].Value() != "supersecret" {
-		t.Errorf("Password = %q, want \"supersecret\"", m.ConnInputs[3].Value())
+	if m.ConnInputs[3].Value() != "default" {
+		t.Errorf("Username = %q, want \"default\"", m.ConnInputs[3].Value())
 	}
-	if m.ConnInputs[4].Value() != "2" {
-		t.Errorf("DB = %q, want \"2\"", m.ConnInputs[4].Value())
+	if m.ConnInputs[4].Value() != "supersecret" {
+		t.Errorf("Password = %q, want \"supersecret\"", m.ConnInputs[4].Value())
+	}
+	if m.ConnInputs[5].Value() != "2" {
+		t.Errorf("DB = %q, want \"2\"", m.ConnInputs[5].Value())
 	}
 }
 
@@ -220,8 +228,9 @@ func TestModel_ConvertCurrentInputsToConnection_Add(t *testing.T) {
 	m.ConnInputs[0].SetValue("My Connection")
 	m.ConnInputs[1].SetValue("redis.example.com")
 	m.ConnInputs[2].SetValue("6380")
-	m.ConnInputs[3].SetValue("secret")
-	m.ConnInputs[4].SetValue("5")
+	m.ConnInputs[3].SetValue("user")
+	m.ConnInputs[4].SetValue("secret")
+	m.ConnInputs[5].SetValue("5")
 	m.ConnClusterMode = true
 	m.ConnFocusIdx = 3
 
@@ -236,6 +245,9 @@ func TestModel_ConvertCurrentInputsToConnection_Add(t *testing.T) {
 	}
 	if conn.Port != 6380 {
 		t.Errorf("Port = %d, want %d", conn.Port, 6380)
+	}
+	if conn.Username != "user" {
+		t.Errorf("Username = %q, want %q", conn.Username, "user")
 	}
 	if conn.Password != "secret" {
 		t.Errorf("Password = %q, want %q", conn.Password, "secret")
@@ -256,8 +268,9 @@ func TestModel_ConvertCurrentInputsToConnection_Edit(t *testing.T) {
 	m.ConnInputs[0].SetValue("My Connection")
 	m.ConnInputs[1].SetValue("redis.example.com")
 	m.ConnInputs[2].SetValue("6380")
-	m.ConnInputs[3].SetValue("secret")
-	m.ConnInputs[4].SetValue("5")
+	m.ConnInputs[3].SetValue("user")
+	m.ConnInputs[4].SetValue("secret")
+	m.ConnInputs[5].SetValue("5")
 	m.ConnClusterMode = true
 	m.ConnFocusIdx = 3
 
@@ -272,6 +285,9 @@ func TestModel_ConvertCurrentInputsToConnection_Edit(t *testing.T) {
 	}
 	if conn.Port != 6380 {
 		t.Errorf("Port = %d, want %d", conn.Port, 6380)
+	}
+	if conn.Username != "user" {
+		t.Errorf("Username = %q, want %q", conn.Username, "user")
 	}
 	if conn.Password != "secret" {
 		t.Errorf("Password = %q, want %q", conn.Password, "secret")

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -107,7 +107,7 @@ func TestModel_GetDB(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := NewModel()
-			m.ConnInputs[4].SetValue(tt.value)
+			m.ConnInputs[5].SetValue(tt.value)
 
 			got := m.getDB()
 			if got != tt.expected {

--- a/internal/ui/screens_connection.go
+++ b/internal/ui/screens_connection.go
@@ -66,13 +66,13 @@ func (m Model) handleAddConnectionScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.focusConnField()
 	case " ":
-		if m.ConnFocusIdx == 4 {
+		if m.ConnFocusIdx == 5 {
 			m.ConnClusterMode = !m.ConnClusterMode
 			return m, nil
 		}
 		return m.updateConnInputs(msg)
 	case "enter":
-		if m.ConnFocusIdx == 4 {
+		if m.ConnFocusIdx == 5 {
 			m.ConnClusterMode = !m.ConnClusterMode
 			return m, nil
 		}
@@ -103,11 +103,11 @@ func (m Model) handleAddConnectionScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // Indices 0-3 map directly to ConnInputs[0-3], index 4 is the cluster toggle (no input),
 // and index 5 maps to ConnInputs[4] (Database).
 func connInputIndex(focusIdx int) int {
-	if focusIdx <= 3 {
+	if focusIdx <= 4 {
 		return focusIdx
 	}
-	if focusIdx == 5 {
-		return 4 // Database input
+	if focusIdx == 6 {
+		return 5 // Database input
 	}
 	return -1 // cluster toggle, no text input
 }
@@ -153,13 +153,13 @@ func (m Model) handleEditConnectionScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.focusConnField()
 	case " ":
-		if m.ConnFocusIdx == 4 {
+		if m.ConnFocusIdx == 5 {
 			m.ConnClusterMode = !m.ConnClusterMode
 			return m, nil
 		}
 		return m.updateConnInputs(msg)
 	case "enter":
-		if m.ConnFocusIdx == 4 {
+		if m.ConnFocusIdx == 5 {
 			m.ConnClusterMode = !m.ConnClusterMode
 			return m, nil
 		}

--- a/internal/ui/screens_connection.go
+++ b/internal/ui/screens_connection.go
@@ -100,8 +100,8 @@ func (m Model) handleAddConnectionScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 // connInputIndex maps a ConnFocusIdx to the actual ConnInputs array index.
-// Indices 0-3 map directly to ConnInputs[0-3], index 4 is the cluster toggle (no input),
-// and index 5 maps to ConnInputs[4] (Database).
+// Indices 0-4 map directly to ConnInputs[0-4], index 5 is the cluster toggle (no input),
+// and index 6 maps to ConnInputs[5] (Database).
 func connInputIndex(focusIdx int) int {
 	if focusIdx <= 4 {
 		return focusIdx

--- a/internal/ui/screens_connection_test.go
+++ b/internal/ui/screens_connection_test.go
@@ -130,13 +130,13 @@ func TestHandleAddConnectionScreen(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		result, _ := m.handleAddConnectionScreen(tea.KeyMsg{Type: tea.KeyShiftTab})
 		model := result.(Model)
-		if model.ConnFocusIdx != 5 {
-			t.Errorf("expected ConnFocusIdx=5, got %d", model.ConnFocusIdx)
+		if model.ConnFocusIdx != 6 {
+			t.Errorf("expected ConnFocusIdx=6, got %d", model.ConnFocusIdx)
 		}
 	})
 	t.Run("space on cluster toggle", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
-		m.ConnFocusIdx = 4
+		m.ConnFocusIdx = 5
 		result, _ := m.handleAddConnectionScreen(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
 		model := result.(Model)
 		if !model.ConnClusterMode {
@@ -145,7 +145,7 @@ func TestHandleAddConnectionScreen(t *testing.T) {
 	})
 	t.Run("space on cluster toggle adjusts focus", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
-		m.ConnFocusIdx = 4
+		m.ConnFocusIdx = 5
 		m.ConnClusterMode = false
 		// Force an out-of-range focus scenario by pre-setting then toggling
 		_, _ = m.handleAddConnectionScreen(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
@@ -156,7 +156,7 @@ func TestHandleAddConnectionScreen(t *testing.T) {
 	})
 	t.Run("enter on cluster toggle", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
-		m.ConnFocusIdx = 4
+		m.ConnFocusIdx = 5
 		result, _ := m.handleAddConnectionScreen(tea.KeyMsg{Type: tea.KeyEnter})
 		model := result.(Model)
 		if !model.ConnClusterMode {
@@ -213,13 +213,13 @@ func TestHandleEditConnectionScreen(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		result, _ := m.handleEditConnectionScreen(tea.KeyMsg{Type: tea.KeyShiftTab})
 		model := result.(Model)
-		if model.ConnFocusIdx != 5 {
+		if model.ConnFocusIdx != 6 {
 			t.Errorf("expected ConnFocusIdx=5, got %d", model.ConnFocusIdx)
 		}
 	})
 	t.Run("space on cluster", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
-		m.ConnFocusIdx = 4
+		m.ConnFocusIdx = 5
 		result, _ := m.handleEditConnectionScreen(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}})
 		model := result.(Model)
 		if !model.ConnClusterMode {
@@ -232,7 +232,7 @@ func TestHandleEditConnectionScreen(t *testing.T) {
 	})
 	t.Run("enter on cluster toggle", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
-		m.ConnFocusIdx = 4
+		m.ConnFocusIdx = 5
 		result, _ := m.handleEditConnectionScreen(tea.KeyMsg{Type: tea.KeyEnter})
 		model := result.(Model)
 		if !model.ConnClusterMode {
@@ -298,9 +298,13 @@ func TestConnInputIndex(t *testing.T) {
 		focus    int
 		expected int
 	}{
-		{0, 0}, {1, 1}, {2, 2}, {3, 3},
-		{4, -1}, // cluster toggle
-		{5, 4},  // DB maps to input 4
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 3},
+		{4, 4},
+		{5, -1}, // cluster toggle
+		{6, 5},  // DB maps to input 5
 	}
 	for _, tt := range tests {
 		if got := connInputIndex(tt.focus); got != tt.expected {

--- a/internal/ui/screens_keys.go
+++ b/internal/ui/screens_keys.go
@@ -274,7 +274,7 @@ func (m Model) handleKeysScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.ExpiringKeys = expiring
 		m.Screen = types.ScreenExpiringKeys
-	case "esc":
+	case "esc", "q":
 		if m.KeyPattern != "" {
 			m.PatternInput.SetValue("")
 			m.KeyPattern = ""

--- a/internal/ui/screens_keys.go
+++ b/internal/ui/screens_keys.go
@@ -274,7 +274,7 @@ func (m Model) handleKeysScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.ExpiringKeys = expiring
 		m.Screen = types.ScreenExpiringKeys
-	case "esc", "q":
+	case "esc":
 		if m.KeyPattern != "" {
 			m.PatternInput.SetValue("")
 			m.KeyPattern = ""

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -268,9 +268,6 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.Screen == types.ScreenConnections {
 			return m, tea.Quit
 		}
-		if m.Screen == types.ScreenKeys {
-			return m, tea.Quit
-		}
 	case "?":
 		if m.Screen != types.ScreenHelp && m.Screen != types.ScreenAddConnection &&
 			m.Screen != types.ScreenEditConnection && m.Screen != types.ScreenAddKey &&

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -268,6 +268,9 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.Screen == types.ScreenConnections {
 			return m, tea.Quit
 		}
+		if m.Screen == types.ScreenKeys {
+			return m, tea.Quit
+		}
 	case "?":
 		if m.Screen != types.ScreenHelp && m.Screen != types.ScreenAddConnection &&
 			m.Screen != types.ScreenEditConnection && m.Screen != types.ScreenAddKey &&

--- a/internal/ui/view_connections.go
+++ b/internal/ui/view_connections.go
@@ -320,7 +320,7 @@ func (m Model) renderConnForm() string {
 		b.WriteString("\n\n")
 	}
 
-	// Field 4: Cluster toggle
+	// Field 5: Cluster toggle
 	clusterLabelStyle := keyStyle
 	if m.ConnFocusIdx == len(textLabels) {
 		clusterLabelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
@@ -338,7 +338,7 @@ func (m Model) renderConnForm() string {
 	b.WriteString(checkboxStyle.Render(checkbox))
 	b.WriteString("\n\n")
 
-	// Field 5: Database (only when not in cluster mode)
+	// Field 6: Database (only when not in cluster mode)
 	if !m.ConnClusterMode {
 		dbLabelStyle := keyStyle
 		if m.ConnFocusIdx == len(textLabels)+1 {

--- a/internal/ui/view_connections.go
+++ b/internal/ui/view_connections.go
@@ -308,8 +308,8 @@ func (m Model) renderConnForm() string {
 	var b strings.Builder
 
 	// Fields 0-3: Name, Host, Port, Password (text inputs)
-	textLabels := []string{"Name", "Host", "Port", "Password"}
-	for i := range 4 {
+	textLabels := []string{"Name", "Host", "Port", "Username", "Password"}
+	for i := range textLabels {
 		labelStyle := keyStyle
 		if m.ConnFocusIdx == i {
 			labelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
@@ -322,7 +322,7 @@ func (m Model) renderConnForm() string {
 
 	// Field 4: Cluster toggle
 	clusterLabelStyle := keyStyle
-	if m.ConnFocusIdx == 4 {
+	if m.ConnFocusIdx == len(textLabels) {
 		clusterLabelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
 	}
 	b.WriteString(clusterLabelStyle.Render("Cluster:"))
@@ -332,7 +332,7 @@ func (m Model) renderConnForm() string {
 		checkbox = "[x] Cluster Mode"
 	}
 	checkboxStyle := normalStyle
-	if m.ConnFocusIdx == 4 {
+	if m.ConnFocusIdx == len(textLabels) {
 		checkboxStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
 	}
 	b.WriteString(checkboxStyle.Render(checkbox))
@@ -341,12 +341,12 @@ func (m Model) renderConnForm() string {
 	// Field 5: Database (only when not in cluster mode)
 	if !m.ConnClusterMode {
 		dbLabelStyle := keyStyle
-		if m.ConnFocusIdx == 5 {
+		if m.ConnFocusIdx == len(textLabels)+1 {
 			dbLabelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
 		}
 		b.WriteString(dbLabelStyle.Render("Database:"))
 		b.WriteString("\n")
-		b.WriteString(m.ConnInputs[4].View())
+		b.WriteString(m.ConnInputs[5].View())
 		b.WriteString("\n\n")
 	}
 

--- a/internal/ui/view_connections.go
+++ b/internal/ui/view_connections.go
@@ -303,11 +303,11 @@ func (m Model) viewEditConnection() string {
 	return lipgloss.Place(m.Width, m.Height, lipgloss.Center, lipgloss.Center, modalStyle.Render(b.String()))
 }
 
-// renderConnForm renders the shared connection form fields (name, host, port, password, cluster toggle, database).
+// renderConnForm renders the shared connection form fields (name, host, port, username, password, cluster toggle, database).
 func (m Model) renderConnForm() string {
 	var b strings.Builder
 
-	// Fields 0-3: Name, Host, Port, Password (text inputs)
+	// Fields 0-4: Name, Host, Port, Username, Password (text inputs)
 	textLabels := []string{"Name", "Host", "Port", "Username", "Password"}
 	for i := range textLabels {
 		labelStyle := keyStyle

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -101,7 +101,7 @@ func TestRenderConnForm(t *testing.T) {
 		}
 	})
 	t.Run("focus on each field", func(t *testing.T) {
-		for i := 0; i <= 5; i++ {
+		for i := 0; i <= 6; i++ {
 			m, _, _ := newTestModel(t)
 			m.ConnFocusIdx = i
 			assertNonEmpty(t, "focus", m.renderConnForm())

--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func parseFlags(args []string) (conn *types.Connection, showVersion bool, doUpda
 
 	host := fs.String("host", "", "Redis server hostname (required for quick-connect mode)")
 	port := fs.Int("port", 6379, "Redis server port")
+	username := fs.String("user", "", "Redis username (for ACL-enabled servers)")
 	password := fs.String("password", "", "Redis password")
 	dbNum := fs.Int("db", 0, "Redis database number (0-15)")
 	name := fs.String("name", "", "Connection display name")
@@ -144,6 +145,7 @@ func parseFlags(args []string) (conn *types.Connection, showVersion bool, doUpda
 		fmt.Fprintf(os.Stderr, "  -p, --port int          Redis server port (default 6379)\n")
 		fmt.Fprintf(os.Stderr, "  -a, --password string   Redis password\n")
 		fmt.Fprintf(os.Stderr, "  -n, --db int            Redis database number, 0-15 (default 0)\n")
+		fmt.Fprintf(os.Stderr, "      --user string       Redis username (for ACL-enabled servers)\n")
 		fmt.Fprintf(os.Stderr, "      --name string       Connection display name\n")
 		fmt.Fprintf(os.Stderr, "      --cluster           Enable cluster mode\n")
 		fmt.Fprintf(os.Stderr, "      --tls               Enable TLS/SSL\n")
@@ -184,6 +186,7 @@ func parseFlags(args []string) (conn *types.Connection, showVersion bool, doUpda
 	conn = &types.Connection{
 		Host:       *host,
 		Port:       *port,
+		Username:   *username,
 		Password:   *password,
 		DB:         *dbNum,
 		UseCluster: *cluster,

--- a/main_test.go
+++ b/main_test.go
@@ -77,7 +77,7 @@ func TestParseFlags_ShortFlags(t *testing.T) {
 }
 
 func TestParseFlags_LongFlags(t *testing.T) {
-	conn, _, _, _, _, err := parseFlags([]string{"--host", "10.0.0.1", "--port", "7000", "--password", "pass", "--db", "3"})
+	conn, _, _, _, _, err := parseFlags([]string{"--host", "10.0.0.1", "--port", "7000", "--user", "user", "--password", "pass", "--db", "3"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -89,6 +89,9 @@ func TestParseFlags_LongFlags(t *testing.T) {
 	}
 	if conn.Port != 7000 {
 		t.Errorf("Port = %d, want %d", conn.Port, 7000)
+	}
+	if conn.Username != "user" {
+		t.Errorf("Username = %q, want %q", conn.Username, "user")
 	}
 	if conn.Password != "pass" {
 		t.Errorf("Password = %q, want %q", conn.Password, "pass")
@@ -205,6 +208,7 @@ func TestParseFlags_AllOptions(t *testing.T) {
 	conn, _, _, _, _, err := parseFlags([]string{
 		"--host", "redis.prod.com",
 		"--port", "6380",
+		"--user", "admin",
 		"--password", "s3cret",
 		"--db", "7",
 		"--name", "Prod Redis",
@@ -226,6 +230,9 @@ func TestParseFlags_AllOptions(t *testing.T) {
 	}
 	if conn.Port != 6380 {
 		t.Errorf("Port = %d", conn.Port)
+	}
+	if conn.Username != "admin" {
+		t.Errorf("Username = %q", conn.Username)
 	}
 	if conn.Password != "s3cret" {
 		t.Errorf("Password = %q", conn.Password)


### PR DESCRIPTION
## Description

Adds username field to the connection form, allows saving username to config, and passes the username through to the Redis connect commands.

Also fixes a small (perceived, this might be intentional) bug: When pressing `q` on the keys page, it quits the whole TUI - when the label is marked `q: back`. Fixes the key logic to make q on the keys page go back to the connections screen.

Fixes #22 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
