### PR TITLE
fix: bump Go to 1.26.3 in workflows and go.mod to clear stdlib advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
+          check-latest: true
           cache: true
 
       - name: Download dependencies
@@ -85,6 +86,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
+          check-latest: true
           cache: true
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
-          check-latest: true
+          go-version: "1.26.3"
           cache: true
 
       - name: Download dependencies
@@ -85,8 +84,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
-          check-latest: true
+          go-version: "1.26.3"
           cache: true
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          check-latest: true
           cache: true
 
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
-          check-latest: true
+          go-version: '1.26.3'
           cache: true
 
       - name: Run GoReleaser

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
-          check-latest: true
+          go-version: '1.26.3'
           cache: true
 
       - name: Run Gosec

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          check-latest: true
           cache: true
 
       - name: Run Gosec

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/davidbudnick/redis-tui
 
-go 1.26
+go 1.26.3
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0


### PR DESCRIPTION
## Context

The Security Scan workflow (`govulncheck`) started failing on every PR and on `main` itself with two stdlib advisories:

- [GO-2026-4971](https://pkg.go.dev/vuln/GO-2026-4971) — `net.Dial` / `LookupPort` panic on NUL byte (Windows). Fixed in `net@go1.26.3`.
- [GO-2026-4918](https://pkg.go.dev/vuln/GO-2026-4918) — `net/http` HTTP/2 infinite loop on bad `SETTINGS_MAX_FRAME_SIZE`. Fixed in `net/http@go1.26.3`.

This PR raises the project's Go version to **1.26.3** in two places that need to stay in sync: the CI/Security/Release workflows, and the `go` directive in `go.mod`. Pinning only one would either leave CI red (`go.mod` lower than CI runtime is harmless, but workflows still pulling 1.26.2 keeps the scan failing) or leave source builders on a vulnerable toolchain (`go.mod` says 1.26 → `GOTOOLCHAIN=auto` happily uses any 1.26.x).

Go 1.26.3 is published on `go.dev/dl`, but `actions/setup-go` resolves loose specs like `1.26` against the [`actions/go-versions`](https://github.com/actions/go-versions) manifest, which currently only lists `1.26.0`, `1.26.1`, `1.26.2`. `check-latest: true` re-checks the same lagging manifest, so it was not enough — the first attempt at this fix failed for that exact reason.

## Demo

Local verification under `go1.26.3` (auto-fetched via `GOTOOLCHAIN=auto` after the `go.mod` bump):

```
$ go test -race ./...
ok  github.com/davidbudnick/redis-tui                     2.327s
ok  github.com/davidbudnick/redis-tui/examples/seed       14.900s
ok  github.com/davidbudnick/redis-tui/internal/cmd        4.318s
ok  github.com/davidbudnick/redis-tui/internal/db         3.177s
ok  github.com/davidbudnick/redis-tui/internal/redis      17.146s
ok  github.com/davidbudnick/redis-tui/internal/service    3.456s
ok  github.com/davidbudnick/redis-tui/internal/testutil   2.768s
ok  github.com/davidbudnick/redis-tui/internal/types      1.790s
ok  github.com/davidbudnick/redis-tui/internal/ui         6.521s

$ go vet ./...
(no output — clean)

$ govulncheck ./...
No vulnerabilities found.
```

(Same `govulncheck@v1.1.4` the workflow uses; previously reported both `GO-2026-4971` and `GO-2026-4918` against the 1.26.2 stdlib.)

## Changes

- Bump the `go` directive in `go.mod` from `1.26` to `1.26.3` so the module's required toolchain matches CI; with `GOTOOLCHAIN=auto` (the default since Go 1.21) anyone building from source auto-fetches the patched toolchain. `go.sum` is unchanged: `go.mod`.
- Pin `go-version` to `'1.26.3'` exactly in all three workflows; `setup-go` falls back to downloading directly from `go.dev/dl` when a version isn't in the manifest: `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `.github/workflows/security.yml`.

## Notes

- Once `actions/go-versions` publishes 1.26.3 we can relax the workflow pin back to `'1.26'` if we want floating patches; the `go.mod` directive can stay at `1.26.3` either way (it's a minimum, not a ceiling).
- README still says "Go 1.26 or later" in a few spots. Strictly accurate would be "Go 1.26.3 or later," but the looser wording remains a fine soft requirement statement; left untouched here to avoid colliding with #31.
