### PR TITLE
fix: bump go to 1.26.4, codecov-action to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
 
       - name: Download dependencies
@@ -62,7 +62,7 @@ jobs:
           echo "All functions at 100% coverage"
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage.out
           fail_ci_if_error: false
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Run GoReleaser

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: true
 
       - name: Run Gosec

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/davidbudnick/redis-tui
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain to **1.26.4** and `codecov/codecov-action` to **v7**.

The Security Scan workflow (`govulncheck`) has been failing on every open PR — not because of the codecov bump, but because the repo pins **go1.26.3**, which `govulncheck` flags for two standard-library vulnerabilities fixed in **go1.26.4**:

- **GO-2026-5039** — arbitrary inputs included in errors without escaping in `net/textproto`
- **GO-2026-5037** — inefficient candidate hostname parsing in `crypto/x509`

## Changes

- `go.mod`: `go 1.26.3` → `1.26.4`
- `.github/workflows/{ci,security,release}.yml`: `go-version` `1.26.3` → `1.26.4`
- `.github/workflows/ci.yml`: `codecov/codecov-action@v6` → `@v7`

## Verification

Locally with go1.26.4:

- `govulncheck ./...` → **No vulnerabilities found** (exit 0)
- `go build ./...` → OK
- `go test ./...` → all packages pass

## Notes

Supersedes #37 (the Dependabot codecov bump); Dependabot will auto-close it once the action is updated on `main`.
