### PR TITLE
fix: clipboard paste and copy in text inputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ make test         # Run tests: go test -v ./...
 make test-cover   # Tests with coverage report
 make lint         # Run go vet
 make fmt          # Format code with go fmt
-make run          # Run the application
+make run          # Build and run the application (make start is an alias)
 make dev-deps         # Install goreleaser
 make test-cover-check # Tests + fail if any function < 100% coverage
 ```

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
 
-.PHONY: all build install clean test test-cover test-cover-check lint run release snapshot demo \
+.PHONY: all build install clean test test-cover test-cover-check lint run start release snapshot demo \
 	docker-up docker-down docker-seed \
 	docker-up-standalone docker-up-standalone-stack docker-up-cluster docker-up-cluster-stack \
 	docker-down-standalone docker-down-standalone-stack docker-down-cluster docker-down-cluster-stack \
@@ -66,9 +66,12 @@ lint:
 fmt:
 	go fmt ./...
 
-## Run the application
-run:
-	go run ./
+## Build and run the application
+run: build
+	./bin/$(APP_NAME)
+
+## Alias for run
+start: run
 
 ## Run the application in debug mode
 debug-server:
@@ -173,7 +176,8 @@ help:
 	@echo "    test-cover-check  - Fail if any function < 100%%"
 	@echo "    lint        - Run linter"
 	@echo "    fmt         - Format code"
-	@echo "    run         - Run the application"
+	@echo "    run         - Build and run the application"
+	@echo "    start       - Alias for run"
 	@echo "    build-all   - Build for multiple platforms"
 	@echo "    release     - Create a release with goreleaser"
 	@echo "    snapshot    - Create a snapshot release"

--- a/internal/ui/screens_keys.go
+++ b/internal/ui/screens_keys.go
@@ -229,6 +229,10 @@ func (m Model) handleKeysScreen(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.Screen = types.ScreenTreeView
 		m.Loading = true
 		return m, m.Cmds.LoadKeyPrefixes(m.TreeSeparator, 3)
+	case "y":
+		if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys) {
+			return m, m.Cmds.CopyToClipboard(m.Keys[m.SelectedKeyIdx].Key)
+		}
 	case "ctrl+g":
 		m.Loading = true
 		return m, m.Cmds.LoadRedisConfig("*")

--- a/internal/ui/screens_keys_test.go
+++ b/internal/ui/screens_keys_test.go
@@ -163,6 +163,21 @@ func TestHandleKeysScreen_Actions(t *testing.T) {
 			t.Error("expected nil cmd")
 		}
 	})
+	t.Run("y copies selected key name", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		seedKeys(&m, 2)
+		_, cmd := m.handleKeysScreen(keyMsg('y'))
+		if cmd == nil {
+			t.Error("expected clipboard cmd")
+		}
+	})
+	t.Run("y with no keys", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		_, cmd := m.handleKeysScreen(keyMsg('y'))
+		if cmd != nil {
+			t.Error("expected nil cmd")
+		}
+	})
 	t.Run("a adds key", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		result, _ := m.handleKeysScreen(keyMsg('a'))

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -22,6 +22,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		return m.handleKeyPress(msg)
 
+	case tea.PasteMsg:
+		return m.handlePaste(msg)
+
 	case types.SearchDebounceMsg:
 		if msg.Seq == m.SearchSeq {
 			pattern := m.Inputs.PatternInput.Value()

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -263,6 +263,10 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "ctrl+c":
 		return m, tea.Quit
+	case "ctrl+y":
+		if value, ok := m.focusedInputValue(); ok && value != "" {
+			return m, m.Cmds.CopyToClipboard(value)
+		}
 	case "q":
 		if m.Screen == types.ScreenConnections {
 			return m, tea.Quit

--- a/internal/ui/update_copy.go
+++ b/internal/ui/update_copy.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"charm.land/bubbles/v2/textinput"
+	"github.com/davidbudnick/redis-tui/internal/types"
+)
+
+// focusedInputValue returns the text of the focused input on the current screen.
+func (m Model) focusedInputValue() (string, bool) {
+	switch m.Screen {
+	case types.ScreenAddConnection, types.ScreenEditConnection:
+		return focusedValue(m.ConnInputs...)
+	case types.ScreenKeys:
+		if m.Inputs.PatternInput.Focused() {
+			return m.Inputs.PatternInput.Value(), true
+		}
+	case types.ScreenAddKey:
+		return focusedValue(m.AddKeyInputs...)
+	case types.ScreenAddToCollection:
+		return focusedValue(m.AddCollectionInput...)
+	case types.ScreenPubSub, types.ScreenPublishMessage:
+		return focusedValue(m.PubSubInput...)
+	case types.ScreenTTLEditor:
+		return focusedValue(m.Inputs.TTLInput)
+	case types.ScreenRenameKey:
+		return focusedValue(m.Inputs.RenameInput)
+	case types.ScreenCopyKey:
+		return focusedValue(m.Inputs.CopyInput)
+	case types.ScreenSwitchDB:
+		return focusedValue(m.Inputs.DBSwitchInput)
+	case types.ScreenSearchValues:
+		return focusedValue(m.Inputs.SearchValueInput)
+	case types.ScreenExport:
+		return focusedValue(m.Inputs.ExportInput)
+	case types.ScreenImport:
+		return focusedValue(m.Inputs.ImportInput)
+	case types.ScreenLuaScript:
+		return focusedValue(m.Inputs.LuaScriptInput)
+	case types.ScreenBulkDelete:
+		return focusedValue(m.Inputs.BulkDeleteInput)
+	case types.ScreenBatchTTL:
+		return focusedValue(m.Inputs.BatchTTLInput, m.Inputs.BatchTTLPattern)
+	case types.ScreenRegexSearch:
+		return focusedValue(m.Inputs.RegexSearchInput)
+	case types.ScreenFuzzySearch:
+		return focusedValue(m.Inputs.FuzzySearchInput)
+	case types.ScreenCompareKeys:
+		return focusedValue(m.Inputs.CompareKey1Input, m.Inputs.CompareKey2Input)
+	case types.ScreenJSONPath:
+		return focusedValue(m.Inputs.JSONPathInput)
+	case types.ScreenRedisConfig:
+		return focusedValue(m.Inputs.ConfigEditInput)
+	}
+	return "", false
+}
+
+func focusedValue(inputs ...textinput.Model) (string, bool) {
+	for i := range inputs {
+		if inputs[i].Focused() {
+			return inputs[i].Value(), true
+		}
+	}
+	return "", false
+}

--- a/internal/ui/update_copy_test.go
+++ b/internal/ui/update_copy_test.go
@@ -1,0 +1,156 @@
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/davidbudnick/redis-tui/internal/types"
+)
+
+func ctrlY() tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: 'y', Mod: tea.ModCtrl}
+}
+
+func TestFocusedInputValue_SingleInputScreens(t *testing.T) {
+	cases := []struct {
+		name   string
+		screen types.Screen
+		focus  func(m *Model)
+	}{
+		{"ttl editor", types.ScreenTTLEditor, func(m *Model) { m.Inputs.TTLInput.Focus(); m.Inputs.TTLInput.SetValue("60") }},
+		{"rename key", types.ScreenRenameKey, func(m *Model) { m.Inputs.RenameInput.Focus(); m.Inputs.RenameInput.SetValue("60") }},
+		{"copy key", types.ScreenCopyKey, func(m *Model) { m.Inputs.CopyInput.Focus(); m.Inputs.CopyInput.SetValue("60") }},
+		{"switch db", types.ScreenSwitchDB, func(m *Model) { m.Inputs.DBSwitchInput.Focus(); m.Inputs.DBSwitchInput.SetValue("60") }},
+		{"search values", types.ScreenSearchValues, func(m *Model) { m.Inputs.SearchValueInput.Focus(); m.Inputs.SearchValueInput.SetValue("60") }},
+		{"export", types.ScreenExport, func(m *Model) { m.Inputs.ExportInput.Focus(); m.Inputs.ExportInput.SetValue("60") }},
+		{"import", types.ScreenImport, func(m *Model) { m.Inputs.ImportInput.Focus(); m.Inputs.ImportInput.SetValue("60") }},
+		{"lua script", types.ScreenLuaScript, func(m *Model) { m.Inputs.LuaScriptInput.Focus(); m.Inputs.LuaScriptInput.SetValue("60") }},
+		{"bulk delete", types.ScreenBulkDelete, func(m *Model) { m.Inputs.BulkDeleteInput.Focus(); m.Inputs.BulkDeleteInput.SetValue("60") }},
+		{"batch ttl", types.ScreenBatchTTL, func(m *Model) { m.Inputs.BatchTTLPattern.Focus(); m.Inputs.BatchTTLPattern.SetValue("60") }},
+		{"regex search", types.ScreenRegexSearch, func(m *Model) { m.Inputs.RegexSearchInput.Focus(); m.Inputs.RegexSearchInput.SetValue("60") }},
+		{"fuzzy search", types.ScreenFuzzySearch, func(m *Model) { m.Inputs.FuzzySearchInput.Focus(); m.Inputs.FuzzySearchInput.SetValue("60") }},
+		{"compare keys", types.ScreenCompareKeys, func(m *Model) { m.Inputs.CompareKey2Input.Focus(); m.Inputs.CompareKey2Input.SetValue("60") }},
+		{"json path", types.ScreenJSONPath, func(m *Model) { m.Inputs.JSONPathInput.Focus(); m.Inputs.JSONPathInput.SetValue("60") }},
+		{"redis config", types.ScreenRedisConfig, func(m *Model) { m.Inputs.ConfigEditInput.Focus(); m.Inputs.ConfigEditInput.SetValue("60") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _, _ := newTestModel(t)
+			m.Screen = tc.screen
+			tc.focus(&m)
+			value, ok := m.focusedInputValue()
+			if !ok || value != "60" {
+				t.Errorf("expected (60, true), got (%q, %v)", value, ok)
+			}
+		})
+	}
+}
+
+func TestFocusedInputValue_SliceInputScreens(t *testing.T) {
+	t.Run("connection screens", func(t *testing.T) {
+		for _, screen := range []types.Screen{types.ScreenAddConnection, types.ScreenEditConnection} {
+			m, _, _ := newTestModel(t)
+			m.Screen = screen
+			m.ConnInputs[0].SetValue("prod")
+			value, ok := m.focusedInputValue()
+			if !ok || value != "prod" {
+				t.Errorf("expected (prod, true), got (%q, %v)", value, ok)
+			}
+		}
+	})
+	t.Run("add key", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenAddKey
+		m.AddKeyInputs[0].SetValue("user:1")
+		value, ok := m.focusedInputValue()
+		if !ok || value != "user:1" {
+			t.Errorf("expected (user:1, true), got (%q, %v)", value, ok)
+		}
+	})
+	t.Run("add to collection", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenAddToCollection
+		m.AddCollectionInput[0].SetValue("member")
+		value, ok := m.focusedInputValue()
+		if !ok || value != "member" {
+			t.Errorf("expected (member, true), got (%q, %v)", value, ok)
+		}
+	})
+	t.Run("pubsub screens", func(t *testing.T) {
+		for _, screen := range []types.Screen{types.ScreenPubSub, types.ScreenPublishMessage} {
+			m, _, _ := newTestModel(t)
+			m.Screen = screen
+			m.PubSubInput[0].SetValue("events")
+			value, ok := m.focusedInputValue()
+			if !ok || value != "events" {
+				t.Errorf("expected (events, true), got (%q, %v)", value, ok)
+			}
+		}
+	})
+}
+
+func TestFocusedInputValue_KeysScreen(t *testing.T) {
+	t.Run("focused pattern input", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenKeys
+		m.Inputs.PatternInput.Focus()
+		m.Inputs.PatternInput.SetValue("user:*")
+		value, ok := m.focusedInputValue()
+		if !ok || value != "user:*" {
+			t.Errorf("expected (user:*, true), got (%q, %v)", value, ok)
+		}
+	})
+	t.Run("unfocused pattern input", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenKeys
+		if _, ok := m.focusedInputValue(); ok {
+			t.Error("expected ok=false")
+		}
+	})
+}
+
+func TestFocusedInputValue_ScreenWithoutInputs(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.Screen = types.ScreenHelp
+	if _, ok := m.focusedInputValue(); ok {
+		t.Error("expected ok=false")
+	}
+}
+
+func TestFocusedValue_NoneFocused(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.Inputs.BatchTTLInput.SetValue("60")
+	if _, ok := focusedValue(m.Inputs.BatchTTLInput, m.Inputs.BatchTTLPattern); ok {
+		t.Error("expected ok=false when nothing focused")
+	}
+}
+
+func TestUpdate_CtrlY(t *testing.T) {
+	t.Run("copies focused input value", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenRenameKey
+		m.Inputs.RenameInput.Focus()
+		m.Inputs.RenameInput.SetValue("new-name")
+		_, cmd := m.Update(ctrlY())
+		if cmd == nil {
+			t.Error("expected clipboard cmd")
+		}
+	})
+	t.Run("empty focused input falls through", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenRenameKey
+		m.Inputs.RenameInput.Focus()
+		_, cmd := m.Update(ctrlY())
+		if cmd != nil {
+			t.Error("expected nil cmd")
+		}
+	})
+	t.Run("no focused input falls through", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenHelp
+		result, _ := m.Update(ctrlY())
+		if result.(Model).Screen != types.ScreenHelp {
+			t.Error("expected screen unchanged")
+		}
+	})
+}

--- a/internal/ui/update_paste.go
+++ b/internal/ui/update_paste.go
@@ -1,0 +1,93 @@
+package ui
+
+import (
+	"time"
+
+	"charm.land/bubbles/v2/textinput"
+	"github.com/davidbudnick/redis-tui/internal/types"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// handlePaste routes bracketed-paste text to the focused input on the current screen.
+func (m Model) handlePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
+	switch m.Screen {
+	case types.ScreenAddConnection, types.ScreenEditConnection:
+		return m, pasteIntoSlice(m.ConnInputs, msg)
+	case types.ScreenKeys:
+		if !m.Inputs.PatternInput.Focused() {
+			return m, nil
+		}
+		inputCmd := pasteInto(&m.Inputs.PatternInput, msg)
+		m.SearchSeq++
+		seq := m.SearchSeq
+		debounceCmd := tea.Tick(300*time.Millisecond, func(t time.Time) tea.Msg {
+			return types.SearchDebounceMsg{Seq: seq}
+		})
+		return m, tea.Batch(inputCmd, debounceCmd)
+	case types.ScreenAddKey:
+		return m, pasteIntoSlice(m.AddKeyInputs, msg)
+	case types.ScreenAddToCollection:
+		return m, pasteIntoSlice(m.AddCollectionInput, msg)
+	case types.ScreenPubSub, types.ScreenPublishMessage:
+		return m, pasteIntoSlice(m.PubSubInput, msg)
+	case types.ScreenEditValue:
+		if m.VimEditor == nil {
+			return m, nil
+		}
+		updated, cmd := m.VimEditor.Update(msg)
+		m.VimEditor = updated
+		return m, cmd
+	case types.ScreenTTLEditor:
+		return m, pasteInto(&m.Inputs.TTLInput, msg)
+	case types.ScreenRenameKey:
+		return m, pasteInto(&m.Inputs.RenameInput, msg)
+	case types.ScreenCopyKey:
+		return m, pasteInto(&m.Inputs.CopyInput, msg)
+	case types.ScreenSwitchDB:
+		return m, pasteInto(&m.Inputs.DBSwitchInput, msg)
+	case types.ScreenSearchValues:
+		return m, pasteInto(&m.Inputs.SearchValueInput, msg)
+	case types.ScreenExport:
+		return m, pasteInto(&m.Inputs.ExportInput, msg)
+	case types.ScreenImport:
+		return m, pasteInto(&m.Inputs.ImportInput, msg)
+	case types.ScreenLuaScript:
+		return m, pasteInto(&m.Inputs.LuaScriptInput, msg)
+	case types.ScreenBulkDelete:
+		return m, pasteInto(&m.Inputs.BulkDeleteInput, msg)
+	case types.ScreenBatchTTL:
+		return m, tea.Batch(
+			pasteInto(&m.Inputs.BatchTTLInput, msg),
+			pasteInto(&m.Inputs.BatchTTLPattern, msg),
+		)
+	case types.ScreenRegexSearch:
+		return m, pasteInto(&m.Inputs.RegexSearchInput, msg)
+	case types.ScreenFuzzySearch:
+		return m, pasteInto(&m.Inputs.FuzzySearchInput, msg)
+	case types.ScreenCompareKeys:
+		return m, tea.Batch(
+			pasteInto(&m.Inputs.CompareKey1Input, msg),
+			pasteInto(&m.Inputs.CompareKey2Input, msg),
+		)
+	case types.ScreenJSONPath:
+		return m, pasteInto(&m.Inputs.JSONPathInput, msg)
+	case types.ScreenRedisConfig:
+		return m, pasteInto(&m.Inputs.ConfigEditInput, msg)
+	}
+	return m, nil
+}
+
+func pasteInto(input *textinput.Model, msg tea.PasteMsg) tea.Cmd {
+	updated, cmd := input.Update(msg)
+	*input = updated
+	return cmd
+}
+
+func pasteIntoSlice(inputs []textinput.Model, msg tea.PasteMsg) tea.Cmd {
+	cmds := make([]tea.Cmd, len(inputs))
+	for i := range inputs {
+		inputs[i], cmds[i] = inputs[i].Update(msg)
+	}
+	return tea.Batch(cmds...)
+}

--- a/internal/ui/update_paste_test.go
+++ b/internal/ui/update_paste_test.go
@@ -1,0 +1,218 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/davidbudnick/redis-tui/internal/types"
+)
+
+func pasteMsg(content string) tea.PasteMsg {
+	return tea.PasteMsg{Content: content}
+}
+
+func TestUpdate_PasteMsg_SingleInputScreens(t *testing.T) {
+	cases := []struct {
+		name   string
+		screen types.Screen
+		focus  func(m *Model)
+		value  func(m Model) string
+	}{
+		{"ttl editor", types.ScreenTTLEditor, func(m *Model) { m.Inputs.TTLInput.Focus() }, func(m Model) string { return m.Inputs.TTLInput.Value() }},
+		{"rename key", types.ScreenRenameKey, func(m *Model) { m.Inputs.RenameInput.Focus() }, func(m Model) string { return m.Inputs.RenameInput.Value() }},
+		{"copy key", types.ScreenCopyKey, func(m *Model) { m.Inputs.CopyInput.Focus() }, func(m Model) string { return m.Inputs.CopyInput.Value() }},
+		{"switch db", types.ScreenSwitchDB, func(m *Model) { m.Inputs.DBSwitchInput.Focus() }, func(m Model) string { return m.Inputs.DBSwitchInput.Value() }},
+		{"search values", types.ScreenSearchValues, func(m *Model) { m.Inputs.SearchValueInput.Focus() }, func(m Model) string { return m.Inputs.SearchValueInput.Value() }},
+		{"export", types.ScreenExport, func(m *Model) { m.Inputs.ExportInput.Focus() }, func(m Model) string { return m.Inputs.ExportInput.Value() }},
+		{"import", types.ScreenImport, func(m *Model) { m.Inputs.ImportInput.Focus() }, func(m Model) string { return m.Inputs.ImportInput.Value() }},
+		{"lua script", types.ScreenLuaScript, func(m *Model) { m.Inputs.LuaScriptInput.Focus() }, func(m Model) string { return m.Inputs.LuaScriptInput.Value() }},
+		{"bulk delete", types.ScreenBulkDelete, func(m *Model) { m.Inputs.BulkDeleteInput.Focus() }, func(m Model) string { return m.Inputs.BulkDeleteInput.Value() }},
+		{"regex search", types.ScreenRegexSearch, func(m *Model) { m.Inputs.RegexSearchInput.Focus() }, func(m Model) string { return m.Inputs.RegexSearchInput.Value() }},
+		{"fuzzy search", types.ScreenFuzzySearch, func(m *Model) { m.Inputs.FuzzySearchInput.Focus() }, func(m Model) string { return m.Inputs.FuzzySearchInput.Value() }},
+		{"json path", types.ScreenJSONPath, func(m *Model) { m.Inputs.JSONPathInput.Focus() }, func(m Model) string { return m.Inputs.JSONPathInput.Value() }},
+		{"redis config", types.ScreenRedisConfig, func(m *Model) { m.Inputs.ConfigEditInput.Focus() }, func(m Model) string { return m.Inputs.ConfigEditInput.Value() }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _, _ := newTestModel(t)
+			m.Screen = tc.screen
+			tc.focus(&m)
+			result, _ := m.Update(pasteMsg("pasted"))
+			if got := tc.value(result.(Model)); got != "pasted" {
+				t.Errorf("expected pasted, got %q", got)
+			}
+		})
+	}
+}
+
+func TestUpdate_PasteMsg_ConnectionScreens(t *testing.T) {
+	for _, screen := range []types.Screen{types.ScreenAddConnection, types.ScreenEditConnection} {
+		m, _, _ := newTestModel(t)
+		m.Screen = screen
+		result, _ := m.Update(pasteMsg("my-conn"))
+		model := result.(Model)
+		if got := model.ConnInputs[0].Value(); got != "my-conn" {
+			t.Errorf("expected paste in focused name input, got %q", got)
+		}
+		if got := model.ConnInputs[1].Value(); got != "localhost" {
+			t.Errorf("expected unfocused host input untouched, got %q", got)
+		}
+	}
+}
+
+func TestUpdate_PasteMsg_KeysScreenSearch(t *testing.T) {
+	t.Run("focused pattern input receives paste and debounces", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenKeys
+		m.Inputs.PatternInput.Focus()
+		m.SearchSeq = 3
+		result, cmd := m.Update(pasteMsg("user:"))
+		model := result.(Model)
+		if got := model.Inputs.PatternInput.Value(); got != "user:" {
+			t.Errorf("expected user:, got %q", got)
+		}
+		if model.SearchSeq != 4 {
+			t.Errorf("expected SearchSeq 4, got %d", model.SearchSeq)
+		}
+		if cmd == nil {
+			t.Fatal("expected debounce cmd")
+		}
+		batch, ok := cmd().(tea.BatchMsg)
+		if !ok {
+			t.Fatal("expected BatchMsg")
+		}
+		found := false
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			if debounce, ok := c().(types.SearchDebounceMsg); ok {
+				found = true
+				if debounce.Seq != 4 {
+					t.Errorf("expected Seq 4, got %d", debounce.Seq)
+				}
+			}
+		}
+		if !found {
+			t.Error("expected SearchDebounceMsg in batch")
+		}
+	})
+	t.Run("unfocused pattern input ignores paste", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenKeys
+		result, cmd := m.Update(pasteMsg("user:"))
+		if got := result.(Model).Inputs.PatternInput.Value(); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+		if cmd != nil {
+			t.Error("expected nil cmd")
+		}
+	})
+}
+
+func TestUpdate_PasteMsg_AddKeyScreen(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.Screen = types.ScreenAddKey
+	result, _ := m.Update(pasteMsg("key-name"))
+	model := result.(Model)
+	if got := model.AddKeyInputs[0].Value(); got != "key-name" {
+		t.Errorf("expected key-name, got %q", got)
+	}
+	if got := model.AddKeyInputs[1].Value(); got != "" {
+		t.Errorf("expected unfocused value input untouched, got %q", got)
+	}
+}
+
+func TestUpdate_PasteMsg_AddToCollectionScreen(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.Screen = types.ScreenAddToCollection
+	result, _ := m.Update(pasteMsg("member"))
+	if got := result.(Model).AddCollectionInput[0].Value(); got != "member" {
+		t.Errorf("expected member, got %q", got)
+	}
+}
+
+func TestUpdate_PasteMsg_PubSubScreens(t *testing.T) {
+	for _, screen := range []types.Screen{types.ScreenPubSub, types.ScreenPublishMessage} {
+		m, _, _ := newTestModel(t)
+		m.Screen = screen
+		result, _ := m.Update(pasteMsg("channel"))
+		if got := result.(Model).PubSubInput[0].Value(); got != "channel" {
+			t.Errorf("expected channel, got %q", got)
+		}
+	}
+}
+
+func TestUpdate_PasteMsg_EditValueScreen(t *testing.T) {
+	t.Run("paste inserts into editor", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenEditValue
+		m.VimEditor = createVimEditor("", 80, 24, "test.txt")
+		result, _ := m.Update(pasteMsg("pasted value"))
+		if got := result.(Model).VimEditor.Value(); !strings.Contains(got, "pasted value") {
+			t.Errorf("expected editor to contain pasted value, got %q", got)
+		}
+	})
+	t.Run("nil editor is a no-op", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenEditValue
+		m.VimEditor = nil
+		_, cmd := m.Update(pasteMsg("x"))
+		if cmd != nil {
+			t.Error("expected nil cmd")
+		}
+	})
+}
+
+func TestUpdate_PasteMsg_BatchTTLScreen(t *testing.T) {
+	t.Run("ttl input focused", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenBatchTTL
+		m.Inputs.BatchTTLInput.Focus()
+		result, _ := m.Update(pasteMsg("3600"))
+		model := result.(Model)
+		if got := model.Inputs.BatchTTLInput.Value(); got != "3600" {
+			t.Errorf("expected 3600, got %q", got)
+		}
+		if got := model.Inputs.BatchTTLPattern.Value(); got != "" {
+			t.Errorf("expected pattern input untouched, got %q", got)
+		}
+	})
+	t.Run("pattern input focused", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenBatchTTL
+		m.Inputs.BatchTTLPattern.Focus()
+		result, _ := m.Update(pasteMsg("user:*"))
+		model := result.(Model)
+		if got := model.Inputs.BatchTTLPattern.Value(); got != "user:*" {
+			t.Errorf("expected user:*, got %q", got)
+		}
+		if got := model.Inputs.BatchTTLInput.Value(); got != "" {
+			t.Errorf("expected ttl input untouched, got %q", got)
+		}
+	})
+}
+
+func TestUpdate_PasteMsg_CompareKeysScreen(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.Screen = types.ScreenCompareKeys
+	m.Inputs.CompareKey2Input.Focus()
+	result, _ := m.Update(pasteMsg("key2"))
+	model := result.(Model)
+	if got := model.Inputs.CompareKey2Input.Value(); got != "key2" {
+		t.Errorf("expected key2, got %q", got)
+	}
+	if got := model.Inputs.CompareKey1Input.Value(); got != "" {
+		t.Errorf("expected key1 input untouched, got %q", got)
+	}
+}
+
+func TestUpdate_PasteMsg_ScreenWithoutInputs(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.Screen = types.ScreenConnections
+	_, cmd := m.Update(pasteMsg("ignored"))
+	if cmd != nil {
+		t.Error("expected nil cmd")
+	}
+}

--- a/internal/ui/view_modals_help.go
+++ b/internal/ui/view_modals_help.go
@@ -25,6 +25,7 @@ func (m Model) viewHelp() string {
 				{"j/k", "Navigate up/down"},
 				{"Ctrl+U/D", "Page up/down"},
 				{"g/G", "Top/Bottom"},
+				{"Ctrl+Y", "Copy input text"},
 			},
 		},
 		{
@@ -46,6 +47,7 @@ func (m Model) viewHelp() string {
 				{"r", "Refresh keys"},
 				{"l", "Load more keys"},
 				{"/", "Filter by pattern"},
+				{"y", "Copy key name"},
 				{"s/S", "Sort / Toggle direction"},
 				{"v", "Search by value"},
 				{"e", "Export to JSON"},


### PR DESCRIPTION
## Context
Clipboard was broken in both directions. Pasting (Cmd+V) did nothing because Bubble Tea v2 delivers clipboard pastes as `tea.PasteMsg` (bracketed paste) while `Update` only routed `tea.KeyPressMsg`, so pastes were dropped before reaching any input. Copying from inside the app was impossible for anything but the key-detail value: macOS terminals never forward Cmd+C to a TUI (it copies the terminal selection), so the app needs its own copy bindings.

Closes #43

## Demo
Verified end-to-end inside a real tmux session: bracketed paste (`tmux paste-buffer -p`, the same path Ghostty Cmd+V takes) inserts into the focused field, and `ctrl+y` puts the field's text on the macOS clipboard via pbcopy.
- Paste: copy text anywhere, focus any redis-tui input, Cmd+V.
- Copy: `ctrl+y` copies the focused input's text; `y` on the keys list copies the selected key name (`y` on key detail already copied the value).

## Changes
- Add a `tea.PasteMsg` case to `Update` in `internal/ui/update.go`
- Add `handlePaste` per-screen dispatcher in `internal/ui/update_paste.go`; keys-screen search paste triggers the same 300ms debounce as typing
- Add `ctrl+y` copy-focused-input via `focusedInputValue` in `internal/ui/update_copy.go`
- Add `y` on the keys list to copy the selected key name in `internal/ui/screens_keys.go`
- Document both bindings in the help modal (`view_modals_help.go`)
- Full-coverage tests in `update_paste_test.go`, `update_copy_test.go`, `screens_keys_test.go`
- `make run` now builds first and runs `bin/redis-tui`; `make start` added as an alias (`Makefile`, `CLAUDE.md`)
