### PR TITLE
perf: bound Redis fetches and cache renders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Redis TUI Manager — a terminal user interface for managing Redis databases, bu
 ```bash
 make build        # Build binary to bin/redis-tui
 make test         # Run tests: go test -v ./...
+make bench        # Hot-path benchmarks (key scans, preview fetches, rendering)
 make test-cover   # Tests with coverage report
 make lint         # Run go vet
 make fmt          # Format code with go fmt

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
 
-.PHONY: all build install clean test test-cover test-cover-check lint run start release snapshot demo \
+.PHONY: all build install clean test bench test-cover test-cover-check lint run start release snapshot demo \
 	docker-up docker-down docker-seed \
 	docker-up-standalone docker-up-standalone-stack docker-up-cluster docker-up-cluster-stack \
 	docker-down-standalone docker-down-standalone-stack docker-down-cluster docker-down-cluster-stack \
@@ -30,6 +30,10 @@ clean:
 ## Run tests
 test:
 	go test -v -race ./...
+
+## Run performance benchmarks (hot paths: key scans, preview fetches, rendering)
+bench:
+	go test -run XXX -bench . -benchmem -benchtime=5x -count=3 ./internal/redis/ ./internal/ui/
 
 ## Run tests with coverage
 test-cover:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ go install github.com/davidbudnick/redis-tui@latest
 ### Browsing and Editing
 
 - **Key browser** with pattern filtering, regex, and fuzzy search
-- **All data types** — strings, lists, sets, sorted sets, hashes, streams, JSON (RedisJSON), HyperLogLog, bitmaps, geospatial, and protobuf (including s2-compressed wire payloads)
+- **Bounded previews** — the preview panel fetches at most 100 items / 64 KB per key (marked "(preview — N total)" when truncated), so browsing huge keys never blocks the Redis server
+- **All data types** — strings, lists, sets, sorted sets, hashes, streams, JSON (RedisJSON), HyperLogLog, bitmaps, and geospatial
 - **Inline value editor** for editing string and JSON values
 - **Tree view** for hierarchical key navigation
 - **Favorites and recent keys** for quick access
@@ -419,6 +420,9 @@ make test
 
 # Run tests with coverage
 make test-cover
+
+# Run performance benchmarks (key scans, preview fetches, rendering)
+make bench
 
 # Run linter
 make lint

--- a/internal/cmd/commands_keys.go
+++ b/internal/cmd/commands_keys.go
@@ -36,7 +36,7 @@ func (c *Commands) LoadKeyPreview(key string) tea.Cmd {
 		if c.redis == nil {
 			return types.KeyPreviewLoadedMsg{Err: nil}
 		}
-		value, err := c.redis.GetValue(key)
+		value, err := c.redis.GetValuePreview(key)
 		return types.KeyPreviewLoadedMsg{Key: key, Value: value, Err: err}
 	}
 }

--- a/internal/redis/benchhelper_test.go
+++ b/internal/redis/benchhelper_test.go
@@ -1,0 +1,31 @@
+package redis
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/davidbudnick/redis-tui/internal/types"
+)
+
+// setupBenchClient mirrors setupTestClient for benchmarks.
+func setupBenchClient(b *testing.B) (*Client, *miniredis.Miniredis) {
+	b.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		b.Fatalf("failed to start miniredis: %v", err)
+	}
+	b.Cleanup(mr.Close)
+
+	client := NewClient()
+	port, err := strconv.Atoi(mr.Port())
+	if err != nil {
+		b.Fatalf("bad port: %v", err)
+	}
+	if err := client.Connect(types.Connection{Name: "bench", Host: mr.Host(), Port: port}); err != nil {
+		b.Fatalf("failed to connect: %v", err)
+	}
+	b.Cleanup(func() { _ = client.Disconnect() })
+
+	return client, mr
+}

--- a/internal/redis/enumeration.go
+++ b/internal/redis/enumeration.go
@@ -104,6 +104,10 @@ const (
 	scanBatchPrefixes int64 = 500
 	// maxRegexLen is the maximum allowed length for user-provided regex patterns.
 	maxRegexLen = 1024
+	// subtypeProbeBytes is how many leading bytes of a string value are fetched
+	// (via GETRANGE) to detect HLL/protobuf/bitmap subtypes without transferring
+	// the full value on every scan page.
+	subtypeProbeBytes = 256
 )
 
 // ScanKeysWithRegex scans keys using regex pattern with early termination.
@@ -416,8 +420,8 @@ func (c *Client) GetKeyPrefixes(separator string, maxDepth int) ([]string, error
 }
 
 // detectStringSubtypes checks string-typed keys for HLL/protobuf/bitmap subtypes
-// using a single pipeline GET. HYLL prefix → hyperloglog; s2/protobuf binary →
-// protobuf; remaining invalid UTF-8 → bitmap.
+// using a pipeline GETRANGE of the first subtypeProbeBytes bytes — a full GET
+// would transfer entire (possibly huge) values on every scan page.
 func (c *Client) detectStringSubtypes(keys []types.RedisKey) []types.RedisKey {
 	// Collect indices of string keys
 	var stringIdxs []int
@@ -433,7 +437,7 @@ func (c *Client) detectStringSubtypes(keys []types.RedisKey) []types.RedisKey {
 	pipe := c.pipeline()
 	getCmds := make([]*redis.StringCmd, len(stringIdxs))
 	for j, idx := range stringIdxs {
-		getCmds[j] = pipe.Get(c.ctx, keys[idx].Key)
+		getCmds[j] = pipe.GetRange(c.ctx, keys[idx].Key, 0, subtypeProbeBytes-1)
 	}
 	_, _ = pipe.Exec(c.ctx)
 
@@ -442,11 +446,22 @@ func (c *Client) detectStringSubtypes(keys []types.RedisKey) []types.RedisKey {
 		if err != nil {
 			continue
 		}
-		if len(val) >= 4 && val[:4] == "HYLL" {
+		if strings.HasPrefix(val, "HYLL") {
 			keys[idx].Type = types.KeyTypeHyperLogLog
-		} else if decode.LooksLikeProtobuf([]byte(val)) {
+			continue
+		}
+		if decode.LooksLikeProtobuf([]byte(val)) {
 			keys[idx].Type = types.KeyTypeProtobuf
-		} else if isBinaryString(val) {
+			continue
+		}
+		// A full-size probe may split a multi-byte UTF-8 rune at the cut point.
+		binary := isBinaryString(val)
+		if len(val) == subtypeProbeBytes {
+			binary = isBinaryPrefix(val)
+		}
+		// Incomplete probes of large binary values may be compressed protobuf
+		// that only decodes with the full payload — leave type as string.
+		if binary && len(val) < subtypeProbeBytes {
 			keys[idx].Type = types.KeyTypeBitmap
 		}
 	}

--- a/internal/redis/enumeration_test.go
+++ b/internal/redis/enumeration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/davidbudnick/redis-tui/internal/types"
+	"github.com/klauspost/compress/s2"
 	goredis "github.com/redis/go-redis/v9"
 )
 
@@ -1012,5 +1013,51 @@ func TestScanKeys_DetectStringSubtypes_ProtobufProbe(t *testing.T) {
 	}
 	if len(keys) != 1 || keys[0].Type != types.KeyTypeProtobuf {
 		t.Fatalf("got %+v, want protobuf", keys)
+	}
+}
+
+// BenchmarkScanKeysProtobufMenus measures SCAN+subtype detection over many
+// s2-compressed protobuf menu payloads (GETRANGE probe path, not full GET).
+func BenchmarkScanKeysProtobufMenus(b *testing.B) {
+	client, mr := setupBenchClient(b)
+
+	// Build a medium protobuf menu-ish message and s2-compress it.
+	var raw []byte
+	// field 1: menu id
+	raw = append(raw, 0x0a, 0x14)
+	raw = append(raw, []byte("rst-demo:DELIVERY!!!!")[:20]...)
+	// several nested category messages as length-delimited field 5
+	for i := 0; i < 50; i++ {
+		var cat []byte
+		name := fmt.Sprintf("Category-%02d-with-padding", i)
+		cat = append(cat, 0x0a, byte(len(name)))
+		cat = append(cat, name...)
+		cat = append(cat, 0x20, 0x01) // field 4 varint 1
+		raw = append(raw, 0x2a, byte(len(cat)))
+		raw = append(raw, cat...)
+	}
+	// pad to ~200KB of proto then compress
+	pad := make([]byte, 180*1024)
+	for i := range pad {
+		pad[i] = byte(i)
+	}
+	// length-delimited field 10 with pad
+	// use multi-byte varint length carefully - simpler: append repeated string fields
+	for i := 0; i < 2000; i++ {
+		s := fmt.Sprintf("item-description-padding-%04d-xxxxxxxx", i)
+		raw = append(raw, 0x12, byte(len(s)))
+		raw = append(raw, s...)
+	}
+	compressed := s2.Encode(nil, raw)
+	for i := 0; i < 50; i++ {
+		mr.Set(fmt.Sprintf("menu:v4:rst-%02d:DELIVERY", i), string(compressed))
+	}
+
+	b.ReportMetric(float64(len(compressed)), "bytes/key")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := client.ScanKeys("menu:v4:*", 0, 100); err != nil {
+			b.Fatalf("ScanKeys: %v", err)
+		}
 	}
 }

--- a/internal/redis/enumeration_test.go
+++ b/internal/redis/enumeration_test.go
@@ -824,29 +824,10 @@ func TestScanKeys_DetectStringSubtypes_Bitmap(t *testing.T) {
 	}
 }
 
-func TestScanKeys_DetectStringSubtypes_Protobuf(t *testing.T) {
-	client, mr := setupTestClient(t)
-
-	var raw []byte
-	raw = append(raw, 0x0a, 0x04)
-	raw = append(raw, []byte("menu")...)
-	mr.Set("proto:detect", string(raw))
-
-	keys, _, err := client.ScanKeys("proto:detect", 0, 100)
-	if err != nil {
-		t.Fatalf("ScanKeys error: %v", err)
-	}
-	if len(keys) != 1 {
-		t.Fatalf("expected 1 key, got %d", len(keys))
-	}
-	if keys[0].Type != types.KeyTypeProtobuf {
-		t.Errorf("type = %q, want protobuf", keys[0].Type)
-	}
-}
-
 // ---------------------------------------------------------------------------
-// detectStringSubtypes — Get error path on a single string key. We use the
-// fake server to return one key from SCAN, "string" type, then have GET fail.
+// detectStringSubtypes — GetRange error path on a single string key. We use
+// the fake server to return one key from SCAN, "string" type, then have
+// GETRANGE fail.
 // ---------------------------------------------------------------------------
 
 func TestDetectStringSubtypes_GetError(t *testing.T) {
@@ -860,8 +841,8 @@ func TestDetectStringSubtypes_GetError(t *testing.T) {
 			return "+string\r\n"
 		case "TTL":
 			return ":-1\r\n"
-		case "GET":
-			// First GET (the one from detectStringSubtypes) errors out.
+		case "GETRANGE":
+			// First GETRANGE (the one from detectStringSubtypes) errors out.
 			ret := ""
 			firstGet.Do(func() { ret = "-ERR injected\r\n" })
 			if ret != "" {
@@ -951,5 +932,85 @@ func TestScanKeys_PlainZSetNotMisDetected(t *testing.T) {
 	}
 	if keys[0].Type != "zset" {
 		t.Errorf("type = %q, want zset", keys[0].Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// detectStringSubtypes — probe truncation branch (value >= subtypeProbeBytes).
+// ---------------------------------------------------------------------------
+
+func TestScanKeys_DetectStringSubtypes_LargeValues(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	// Large plain-text value: probe returns exactly subtypeProbeBytes bytes and
+	// the key must stay a plain string.
+	mr.Set("large:text", strings.Repeat("a", subtypeProbeBytes*2))
+
+	// Large binary value: incomplete probes stay "string" so large compressed
+	// protobuf blobs are not mislabeled as bitmaps. GetValue still classifies
+	// on open.
+	bin := make([]byte, subtypeProbeBytes*2)
+	for i := range bin {
+		bin[i] = 0xff
+	}
+	mr.Set("large:bin", string(bin))
+
+	// Short complete binary value still classifies as bitmap from the probe alone.
+	mr.Set("short:bin", string([]byte{0xff, 0xfe}))
+
+	keys, _, err := client.ScanKeys("*", 0, 100)
+	if err != nil {
+		t.Fatalf("ScanKeys error: %v", err)
+	}
+	byName := map[string]types.KeyType{}
+	for _, k := range keys {
+		byName[k.Key] = k.Type
+	}
+	if byName["large:text"] != "string" {
+		t.Errorf("large:text type = %q, want string", byName["large:text"])
+	}
+	if byName["large:bin"] != "string" {
+		t.Errorf("large:bin type = %q, want string (incomplete probe)", byName["large:bin"])
+	}
+	if byName["short:bin"] != "bitmap" {
+		t.Errorf("short:bin type = %q, want bitmap", byName["short:bin"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: key-list scan over large string values. Before the GETRANGE
+// probe, every SCAN page pipelined a full GET of each string key, transferring
+// entire values just to sniff HLL/bitmap magic bytes.
+// ---------------------------------------------------------------------------
+
+func BenchmarkScanKeysLargeStringValues(b *testing.B) {
+	client, mr := setupBenchClient(b)
+
+	val := strings.Repeat("x", 512*1024) // 512KB per key
+	for i := 0; i < 100; i++ {
+		mr.Set(fmt.Sprintf("big:%03d", i), val)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := client.ScanKeys("big:*", 0, 100); err != nil {
+			b.Fatalf("ScanKeys: %v", err)
+		}
+	}
+}
+
+func TestScanKeys_DetectStringSubtypes_ProtobufProbe(t *testing.T) {
+	client, mr := setupTestClient(t)
+	// field 1 string "menu"
+	var raw []byte
+	raw = append(raw, 0x0a, 0x04)
+	raw = append(raw, []byte("menu")...)
+	mr.Set("proto:small", string(raw))
+	keys, _, err := client.ScanKeys("proto:small", 0, 10)
+	if err != nil {
+		t.Fatalf("ScanKeys: %v", err)
+	}
+	if len(keys) != 1 || keys[0].Type != types.KeyTypeProtobuf {
+		t.Fatalf("got %+v, want protobuf", keys)
 	}
 }

--- a/internal/redis/operations.go
+++ b/internal/redis/operations.go
@@ -9,8 +9,10 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// maxBitPositions caps how many set-bit offsets we materialize for display.
-const maxBitPositions = 256
+// maxBitPositions caps how many set-bit positions are extracted from a bitmap
+// value — the UI displays only a screenful, and an unbounded extraction of a
+// large bitmap could allocate millions of entries.
+const maxBitPositions = 1024
 
 // GetValue retrieves the value for a key
 func (c *Client) GetValue(key string) (types.RedisValue, error) {
@@ -181,6 +183,24 @@ func extractBitPositions(val []byte, max int) []int64 {
 		}
 	}
 	return positions
+}
+
+// isBinaryPrefix is like isBinaryString but for a value prefix (e.g. from
+// GETRANGE): a multi-byte UTF-8 rune split at the cut point must not count as
+// binary, so up to utf8.UTFMax-1 trailing bytes of an incomplete rune are
+// trimmed before validating.
+func isBinaryPrefix(s string) bool {
+	for i := 0; i < utf8.UTFMax-1 && len(s) > 0; i++ {
+		if utf8.ValidString(s) {
+			return false
+		}
+		r, size := utf8.DecodeLastRuneInString(s)
+		if r != utf8.RuneError || size != 1 {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return isBinaryString(s)
 }
 
 // JSONGet retrieves a JSON value from a RedisJSON key

--- a/internal/redis/operations_test.go
+++ b/internal/redis/operations_test.go
@@ -1204,3 +1204,53 @@ func TestExtractBitPositions_Caps(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 
+
+// BenchmarkGetValueProtobufS2 measures full decode of a large s2+protobuf menu value.
+func BenchmarkGetValueProtobufS2(b *testing.B) {
+	client, mr := setupBenchClient(b)
+
+	var raw []byte
+	raw = append(raw, 0x0a, 0x14)
+	raw = append(raw, []byte("rst-demo:DELIVERY!!!!")[:20]...)
+	for i := 0; i < 3000; i++ {
+		s := fmt.Sprintf("item-description-padding-%04d-xxxxxxxx", i)
+		raw = append(raw, 0x12, byte(len(s)))
+		raw = append(raw, s...)
+	}
+	compressed := s2.Encode(nil, raw)
+	mr.Set("menu:big", string(compressed))
+
+	b.ReportMetric(float64(len(compressed)), "raw-bytes")
+	b.ReportMetric(float64(len(raw)), "decoded-bytes")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v, err := client.GetValue("menu:big")
+		if err != nil {
+			b.Fatalf("GetValue: %v", err)
+		}
+		if v.Type != types.KeyTypeProtobuf {
+			b.Fatalf("type = %s, want protobuf", v.Type)
+		}
+	}
+}
+
+// BenchmarkGetValuePreviewProtobufS2 measures bounded preview of s2+protobuf.
+func BenchmarkGetValuePreviewProtobufS2(b *testing.B) {
+	client, mr := setupBenchClient(b)
+
+	var raw []byte
+	for i := 0; i < 3000; i++ {
+		s := fmt.Sprintf("item-description-padding-%04d-xxxxxxxx", i)
+		raw = append(raw, 0x12, byte(len(s)))
+		raw = append(raw, s...)
+	}
+	compressed := s2.Encode(nil, raw)
+	mr.Set("menu:big", string(compressed))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := client.GetValuePreview("menu:big"); err != nil {
+			b.Fatalf("GetValuePreview: %v", err)
+		}
+	}
+}

--- a/internal/redis/operations_test.go
+++ b/internal/redis/operations_test.go
@@ -606,86 +606,6 @@ func TestGetValue_Bitmap(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// GetValue — Protobuf (raw + s2-compressed) branch
-// ---------------------------------------------------------------------------
-
-func TestGetValue_Protobuf(t *testing.T) {
-	client, mr := setupTestClient(t)
-
-	// field 1 string "menu-id", field 5 varint 7
-	var raw []byte
-	raw = append(raw, 0x0a, 0x07) // tag 1, len 7
-	raw = append(raw, []byte("menu-id")...)
-	raw = append(raw, 0x28, 0x07) // tag 5, varint 7
-
-	mr.Set("proto:raw", string(raw))
-	v, err := client.GetValue("proto:raw")
-	if err != nil {
-		t.Fatalf("GetValue error: %v", err)
-	}
-	if v.Type != types.KeyTypeProtobuf {
-		t.Fatalf("Type = %q, want %q", v.Type, types.KeyTypeProtobuf)
-	}
-	if v.DecodedFormat != "protobuf" {
-		t.Errorf("DecodedFormat = %q, want protobuf", v.DecodedFormat)
-	}
-	if !strings.Contains(v.DecodedValue, `1: "menu-id"`) {
-		t.Errorf("DecodedValue missing menu-id field:\n%s", v.DecodedValue)
-	}
-	if !strings.Contains(v.DecodedValue, "5: 7") {
-		t.Errorf("DecodedValue missing field 5:\n%s", v.DecodedValue)
-	}
-}
-
-func TestGetValue_Protobuf_S2(t *testing.T) {
-	client, mr := setupTestClient(t)
-
-	var raw []byte
-	raw = append(raw, 0x0a, 0x04)
-	raw = append(raw, []byte("abcd")...)
-	compressed := s2.Encode(nil, raw)
-
-	mr.Set("proto:s2", string(compressed))
-	v, err := client.GetValue("proto:s2")
-	if err != nil {
-		t.Fatalf("GetValue error: %v", err)
-	}
-	if v.Type != types.KeyTypeProtobuf {
-		t.Fatalf("Type = %q, want %q", v.Type, types.KeyTypeProtobuf)
-	}
-	if v.DecodedFormat != "s2+protobuf" {
-		t.Errorf("DecodedFormat = %q, want s2+protobuf", v.DecodedFormat)
-	}
-	if v.RawSize != len(compressed) {
-		t.Errorf("RawSize = %d, want %d", v.RawSize, len(compressed))
-	}
-	if v.DecodedSize != len(raw) {
-		t.Errorf("DecodedSize = %d, want %d", v.DecodedSize, len(raw))
-	}
-	if !strings.Contains(v.DecodedValue, `1: "abcd"`) {
-		t.Errorf("DecodedValue missing field:\n%s", v.DecodedValue)
-	}
-}
-
-func TestExtractBitPositions_Caps(t *testing.T) {
-	// 32 bytes all 0xff → 256 set bits; cap at 10.
-	raw := bytes.Repeat([]byte{0xff}, 32)
-	got := extractBitPositions(raw, 10)
-	if len(got) != 10 {
-		t.Fatalf("len = %d, want 10", len(got))
-	}
-	if got[0] != 0 || got[9] != 9 {
-		t.Errorf("positions = %v, want 0..9", got)
-	}
-	if extractBitPositions(raw, 0) != nil {
-		t.Error("max 0 should return nil")
-	}
-	if extractBitPositions(raw, -1) != nil {
-		t.Error("negative max should return nil")
-	}
-}
-
-// ---------------------------------------------------------------------------
 // GetValue — Geo branch
 // ---------------------------------------------------------------------------
 
@@ -1115,3 +1035,172 @@ func TestBulkDelete_LargeKeySet(t *testing.T) {
 		t.Errorf("expected 0 keys remaining, got %d", client.GetTotalKeys())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// isBinaryPrefix — direct unit tests
+// ---------------------------------------------------------------------------
+
+func TestIsBinaryPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{"empty string", "", false},
+		{"valid utf-8 ascii", "hello", false},
+		{"valid utf-8 multibyte", "héllo", false},
+		// A 3-byte rune (é = 0xE4 0xB8 0xAD is 中) cut after 1 byte: not binary.
+		{"split rune one byte left", "hello\xe4", false},
+		// Cut after 2 of 3 bytes: not binary.
+		{"split rune two bytes left", "hello\xe4\xb8", false},
+		// 4-byte rune (😀 = 0xF0 0x9F 0x98 0x80) cut after 3 bytes: not binary.
+		{"split rune three bytes left", "hello\xf0\x9f\x98", false},
+		// Genuinely binary content in the middle survives trimming.
+		{"binary in middle", "a\xffb", true},
+		{"all binary", string([]byte{0xff, 0xfe, 0xfd, 0xfc}), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBinaryPrefix(tt.s)
+			if got != tt.want {
+				t.Errorf("isBinaryPrefix(%q) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractBitPositions — direct unit tests including the cap
+// ---------------------------------------------------------------------------
+
+func TestExtractBitPositions(t *testing.T) {
+	t.Run("positions from bytes", func(t *testing.T) {
+		// 0b10000001 -> bits 0 and 7; 0b01000000 -> bit 9
+		got := extractBitPositions([]byte{0x81, 0x40}, 10)
+		want := []int64{0, 7, 9}
+		if len(got) != len(want) {
+			t.Fatalf("positions = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("positions[%d] = %d, want %d", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("capped at max", func(t *testing.T) {
+		// 4 bytes of 0xFF = 32 set bits, capped at 5.
+		got := extractBitPositions([]byte{0xff, 0xff, 0xff, 0xff}, 5)
+		if len(got) != 5 {
+			t.Fatalf("len = %d, want 5", len(got))
+		}
+		if got[4] != 4 {
+			t.Errorf("last position = %d, want 4", got[4])
+		}
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		if got := extractBitPositions(nil, 5); len(got) != 0 {
+			t.Errorf("expected no positions, got %v", got)
+		}
+	})
+}
+
+func TestIsBinaryPrefixAndExtractMaxZero(t *testing.T) {
+	// incomplete multi-byte rune at end of prefix should not mark binary
+	if isBinaryPrefix("hello\xc2") {
+		t.Error("incomplete UTF-8 trail should not be binary")
+	}
+	// More than utf8.UTFMax-1 invalid trailing bytes remain after prefix trim.
+	if !isBinaryPrefix(string([]byte{0xff, 0xfe, 0xfd, 0xfc})) {
+		t.Error("invalid bytes should be binary")
+	}
+	if extractBitPositions([]byte{0xff}, 0) != nil {
+		t.Error("max 0 should return nil")
+	}
+}
+
+
+func TestGetValue_Protobuf(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	// field 1 string "menu-id", field 5 varint 7
+	var raw []byte
+	raw = append(raw, 0x0a, 0x07) // tag 1, len 7
+	raw = append(raw, []byte("menu-id")...)
+	raw = append(raw, 0x28, 0x07) // tag 5, varint 7
+
+	mr.Set("proto:raw", string(raw))
+	v, err := client.GetValue("proto:raw")
+	if err != nil {
+		t.Fatalf("GetValue error: %v", err)
+	}
+	if v.Type != types.KeyTypeProtobuf {
+		t.Fatalf("Type = %q, want %q", v.Type, types.KeyTypeProtobuf)
+	}
+	if v.DecodedFormat != "protobuf" {
+		t.Errorf("DecodedFormat = %q, want protobuf", v.DecodedFormat)
+	}
+	if !strings.Contains(v.DecodedValue, `1: "menu-id"`) {
+		t.Errorf("DecodedValue missing menu-id field:\n%s", v.DecodedValue)
+	}
+	if !strings.Contains(v.DecodedValue, "5: 7") {
+		t.Errorf("DecodedValue missing field 5:\n%s", v.DecodedValue)
+	}
+}
+
+
+func TestGetValue_Protobuf_S2(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	var raw []byte
+	raw = append(raw, 0x0a, 0x04)
+	raw = append(raw, []byte("abcd")...)
+	compressed := s2.Encode(nil, raw)
+
+	mr.Set("proto:s2", string(compressed))
+	v, err := client.GetValue("proto:s2")
+	if err != nil {
+		t.Fatalf("GetValue error: %v", err)
+	}
+	if v.Type != types.KeyTypeProtobuf {
+		t.Fatalf("Type = %q, want %q", v.Type, types.KeyTypeProtobuf)
+	}
+	if v.DecodedFormat != "s2+protobuf" {
+		t.Errorf("DecodedFormat = %q, want s2+protobuf", v.DecodedFormat)
+	}
+	if v.RawSize != len(compressed) {
+		t.Errorf("RawSize = %d, want %d", v.RawSize, len(compressed))
+	}
+	if v.DecodedSize != len(raw) {
+		t.Errorf("DecodedSize = %d, want %d", v.DecodedSize, len(raw))
+	}
+	if !strings.Contains(v.DecodedValue, `1: "abcd"`) {
+		t.Errorf("DecodedValue missing field:\n%s", v.DecodedValue)
+	}
+}
+
+
+func TestExtractBitPositions_Caps(t *testing.T) {
+	// 32 bytes all 0xff → 256 set bits; cap at 10.
+	raw := bytes.Repeat([]byte{0xff}, 32)
+	got := extractBitPositions(raw, 10)
+	if len(got) != 10 {
+		t.Fatalf("len = %d, want 10", len(got))
+	}
+	if got[0] != 0 || got[9] != 9 {
+		t.Errorf("positions = %v, want 0..9", got)
+	}
+	if extractBitPositions(raw, 0) != nil {
+		t.Error("max 0 should return nil")
+	}
+	if extractBitPositions(raw, -1) != nil {
+		t.Error("negative max should return nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetValue — Geo branch
+// ---------------------------------------------------------------------------
+
+

--- a/internal/redis/preview.go
+++ b/internal/redis/preview.go
@@ -1,0 +1,218 @@
+package redis
+
+import (
+	"strings"
+
+	"github.com/davidbudnick/redis-tui/internal/types"
+)
+
+const (
+	// previewMaxItems caps how many collection entries are fetched for the
+	// keys-list preview panel, which only ever displays a screenful.
+	previewMaxItems = 100
+	// previewMaxStringBytes caps how many bytes of a string value are fetched
+	// for the preview panel.
+	previewMaxStringBytes = 64 * 1024
+)
+
+// GetValuePreview retrieves a bounded preview of a key's value. Unlike
+// GetValue it never fetches entire collections (LRANGE 0 -1, HGETALL,
+// SMEMBERS, ...), so selecting a huge key in the keys list cannot block the
+// Redis server or transfer megabytes for a screenful of preview. When the
+// value was cut off, Truncated is set and TotalCount holds the full
+// length/cardinality.
+func (c *Client) GetValuePreview(key string) (types.RedisValue, error) {
+	keyType, err := c.cmdable().Type(c.ctx, key).Result()
+	if err != nil {
+		return types.RedisValue{}, err
+	}
+
+	var value types.RedisValue
+	value.Type = types.KeyType(keyType)
+
+	switch keyType {
+	case "string":
+		if err := c.previewString(key, &value); err != nil {
+			return value, err
+		}
+
+	case "list":
+		total, err := c.cmdable().LLen(c.ctx, key).Result()
+		if err != nil {
+			return value, err
+		}
+		vals, err := c.cmdable().LRange(c.ctx, key, 0, previewMaxItems-1).Result()
+		if err != nil {
+			return value, err
+		}
+		value.ListValue = vals
+		markTruncated(&value, total, len(vals))
+
+	case "set":
+		total, err := c.cmdable().SCard(c.ctx, key).Result()
+		if err != nil {
+			return value, err
+		}
+		members, err := c.scanSetPreview(key)
+		if err != nil {
+			return value, err
+		}
+		value.SetValue = members
+		markTruncated(&value, total, len(members))
+
+	case "zset":
+		total, err := c.cmdable().ZCard(c.ctx, key).Result()
+		if err != nil {
+			return value, err
+		}
+		vals, err := c.cmdable().ZRangeWithScores(c.ctx, key, 0, previewMaxItems-1).Result()
+		if err != nil {
+			return value, err
+		}
+		for _, z := range vals {
+			value.ZSetValue = append(value.ZSetValue, types.ZSetMember{
+				Member: z.Member.(string),
+				Score:  z.Score,
+			})
+		}
+		markTruncated(&value, total, len(value.ZSetValue))
+		c.previewGeoDetect(key, &value)
+
+	case "hash":
+		total, err := c.cmdable().HLen(c.ctx, key).Result()
+		if err != nil {
+			return value, err
+		}
+		fields, err := c.scanHashPreview(key)
+		if err != nil {
+			return value, err
+		}
+		value.HashValue = fields
+		markTruncated(&value, total, len(fields))
+
+	case "stream":
+		total, err := c.cmdable().XLen(c.ctx, key).Result()
+		if err != nil {
+			return value, err
+		}
+		entries, err := c.cmdable().XRangeN(c.ctx, key, "-", "+", previewMaxItems).Result()
+		if err != nil {
+			return value, err
+		}
+		for _, entry := range entries {
+			value.StreamValue = append(value.StreamValue, types.StreamEntry{
+				ID:     entry.ID,
+				Fields: entry.Values,
+			})
+		}
+		markTruncated(&value, total, len(value.StreamValue))
+
+	case "ReJSON-RL":
+		val, err := c.do("JSON.GET", key, "$").Text()
+		if err != nil {
+			return value, err
+		}
+		value.JSONValue = val
+	}
+
+	return value, nil
+}
+
+// markTruncated sets the Truncated/TotalCount fields when fewer entries were
+// fetched than exist.
+func markTruncated(value *types.RedisValue, total int64, fetched int) {
+	if total > int64(fetched) {
+		value.Truncated = true
+		value.TotalCount = total
+	}
+}
+
+// previewString fills in a bounded string preview, including HLL and bitmap
+// subtype detection on the fetched prefix.
+func (c *Client) previewString(key string, value *types.RedisValue) error {
+	total, err := c.cmdable().StrLen(c.ctx, key).Result()
+	if err != nil {
+		return err
+	}
+	val, err := c.cmdable().GetRange(c.ctx, key, 0, previewMaxStringBytes-1).Result()
+	if err != nil {
+		return err
+	}
+	value.StringValue = val
+	markTruncated(value, total, len(val))
+
+	if strings.HasPrefix(val, "HYLL") {
+		value.Type = types.KeyTypeHyperLogLog
+		if count, err := c.cmdable().PFCount(c.ctx, key).Result(); err == nil {
+			value.HLLCount = count
+		}
+		return nil
+	}
+
+	binary := isBinaryString(val)
+	if value.Truncated {
+		binary = isBinaryPrefix(val)
+	}
+	if binary {
+		value.Type = types.KeyTypeBitmap
+		if count, err := c.cmdable().BitCount(c.ctx, key, nil).Result(); err == nil {
+			value.BitCount = count
+		}
+		value.BitPositions = extractBitPositions([]byte(val), maxBitPositions)
+	}
+	return nil
+}
+
+// scanSetPreview collects roughly previewMaxItems set members from a single
+// SSCAN iteration. COUNT is a hint, so slightly more or fewer entries may be
+// returned — the preview panel only displays a screenful either way.
+func (c *Client) scanSetPreview(key string) ([]string, error) {
+	members, _, err := c.cmdable().SScan(c.ctx, key, 0, "", previewMaxItems).Result()
+	return members, err
+}
+
+// scanHashPreview collects roughly previewMaxItems hash fields from a single
+// HSCAN iteration (returned as flattened field/value pairs). COUNT is only a
+// hint, so servers may return more pairs than asked; inserts are capped so the
+// preview never materializes an unbounded map.
+func (c *Client) scanHashPreview(key string) (map[string]string, error) {
+	batch, _, err := c.cmdable().HScan(c.ctx, key, 0, "", previewMaxItems).Result()
+	if err != nil {
+		return nil, err
+	}
+	fields := make(map[string]string, previewMaxItems)
+	for i := 0; i+1 < len(batch) && len(fields) < previewMaxItems; i += 2 {
+		fields[batch[i]] = batch[i+1]
+	}
+	return fields, nil
+}
+
+// previewGeoDetect flips a zset preview to Geo when its scores look like
+// geohash integers, resolving coordinates for the previewed members.
+func (c *Client) previewGeoDetect(key string, value *types.RedisValue) {
+	if len(value.ZSetValue) == 0 || !looksLikeGeoScores(value.ZSetValue) {
+		return
+	}
+	members := make([]string, len(value.ZSetValue))
+	for i, m := range value.ZSetValue {
+		members[i] = m.Member
+	}
+	positions, err := c.cmdable().GeoPos(c.ctx, key, members...).Result()
+	if err != nil {
+		return
+	}
+	var geoMembers []types.GeoMember
+	for i, pos := range positions {
+		if pos != nil {
+			geoMembers = append(geoMembers, types.GeoMember{
+				Name:      members[i],
+				Longitude: pos.Longitude,
+				Latitude:  pos.Latitude,
+			})
+		}
+	}
+	if len(geoMembers) > 0 {
+		value.Type = types.KeyTypeGeo
+		value.GeoValue = geoMembers
+	}
+}

--- a/internal/redis/preview_test.go
+++ b/internal/redis/preview_test.go
@@ -1,0 +1,562 @@
+package redis
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/davidbudnick/redis-tui/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// GetValuePreview — happy paths per type via miniredis
+// ---------------------------------------------------------------------------
+
+func TestGetValuePreview_NonexistentKey(t *testing.T) {
+	client, _ := setupTestClient(t)
+
+	v, err := client.GetValuePreview("missing")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if v.Type != "none" {
+		t.Errorf("Type = %q, want none", v.Type)
+	}
+	if v.Truncated {
+		t.Error("expected Truncated = false")
+	}
+}
+
+func TestGetValuePreview_StringSmall(t *testing.T) {
+	client, mr := setupTestClient(t)
+	mr.Set("s", "hello")
+
+	v, err := client.GetValuePreview("s")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if v.Type != types.KeyTypeString {
+		t.Errorf("Type = %q, want string", v.Type)
+	}
+	if v.StringValue != "hello" {
+		t.Errorf("StringValue = %q, want hello", v.StringValue)
+	}
+	if v.Truncated {
+		t.Error("expected Truncated = false")
+	}
+}
+
+func TestGetValuePreview_StringTruncated(t *testing.T) {
+	client, mr := setupTestClient(t)
+	total := previewMaxStringBytes + 1024
+	mr.Set("big", strings.Repeat("a", total))
+
+	v, err := client.GetValuePreview("big")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if len(v.StringValue) != previewMaxStringBytes {
+		t.Errorf("StringValue length = %d, want %d", len(v.StringValue), previewMaxStringBytes)
+	}
+	if !v.Truncated {
+		t.Error("expected Truncated = true")
+	}
+	if v.TotalCount != int64(total) {
+		t.Errorf("TotalCount = %d, want %d", v.TotalCount, total)
+	}
+}
+
+func TestGetValuePreview_HyperLogLog(t *testing.T) {
+	client, mr := setupTestClient(t)
+	mr.Set("hll", "HYLL"+string(make([]byte, 12)))
+
+	v, err := client.GetValuePreview("hll")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if v.Type != types.KeyTypeHyperLogLog {
+		t.Errorf("Type = %q, want hyperloglog", v.Type)
+	}
+}
+
+func TestGetValuePreview_Bitmap(t *testing.T) {
+	client, _ := setupTestClient(t)
+	for _, off := range []int64{0, 1, 7} {
+		if err := client.SetBit("bm", off, 1); err != nil {
+			t.Fatalf("SetBit(%d) error: %v", off, err)
+		}
+	}
+
+	v, err := client.GetValuePreview("bm")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if v.Type != types.KeyTypeBitmap {
+		t.Errorf("Type = %q, want bitmap", v.Type)
+	}
+	if v.BitCount != 3 {
+		t.Errorf("BitCount = %d, want 3", v.BitCount)
+	}
+	if len(v.BitPositions) != 3 {
+		t.Errorf("BitPositions length = %d, want 3", len(v.BitPositions))
+	}
+}
+
+func TestGetValuePreview_BitmapTruncated(t *testing.T) {
+	client, mr := setupTestClient(t)
+	// Binary value larger than the preview byte cap.
+	bin := make([]byte, previewMaxStringBytes+512)
+	for i := range bin {
+		bin[i] = 0xff
+	}
+	mr.Set("bigbm", string(bin))
+
+	v, err := client.GetValuePreview("bigbm")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if v.Type != types.KeyTypeBitmap {
+		t.Errorf("Type = %q, want bitmap", v.Type)
+	}
+	if !v.Truncated {
+		t.Error("expected Truncated = true")
+	}
+	if len(v.BitPositions) != maxBitPositions {
+		t.Errorf("BitPositions length = %d, want cap %d", len(v.BitPositions), maxBitPositions)
+	}
+}
+
+func TestGetValuePreview_List(t *testing.T) {
+	t.Run("small list", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		mr.RPush("l", "a", "b", "c")
+
+		v, err := client.GetValuePreview("l")
+		if err != nil {
+			t.Fatalf("GetValuePreview error: %v", err)
+		}
+		if len(v.ListValue) != 3 {
+			t.Errorf("ListValue length = %d, want 3", len(v.ListValue))
+		}
+		if v.Truncated {
+			t.Error("expected Truncated = false")
+		}
+	})
+
+	t.Run("large list is truncated", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		for i := 0; i < previewMaxItems+50; i++ {
+			mr.RPush("biglist", "item")
+		}
+
+		v, err := client.GetValuePreview("biglist")
+		if err != nil {
+			t.Fatalf("GetValuePreview error: %v", err)
+		}
+		if len(v.ListValue) != previewMaxItems {
+			t.Errorf("ListValue length = %d, want %d", len(v.ListValue), previewMaxItems)
+		}
+		if !v.Truncated {
+			t.Error("expected Truncated = true")
+		}
+		if v.TotalCount != int64(previewMaxItems+50) {
+			t.Errorf("TotalCount = %d, want %d", v.TotalCount, previewMaxItems+50)
+		}
+	})
+}
+
+func TestGetValuePreview_Set(t *testing.T) {
+	t.Run("small set", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		mr.SAdd("st", "a", "b", "c")
+
+		v, err := client.GetValuePreview("st")
+		if err != nil {
+			t.Fatalf("GetValuePreview error: %v", err)
+		}
+		if len(v.SetValue) != 3 {
+			t.Errorf("SetValue length = %d, want 3", len(v.SetValue))
+		}
+		if v.Truncated {
+			t.Error("expected Truncated = false")
+		}
+	})
+
+	t.Run("large set is truncated", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		for i := 0; i < previewMaxItems+50; i++ {
+			mr.SAdd("bigset", strings.Repeat("m", 3)+string(rune('0'+i%10))+strings.Repeat("x", i/10))
+		}
+
+		v, err := client.GetValuePreview("bigset")
+		if err != nil {
+			t.Fatalf("GetValuePreview error: %v", err)
+		}
+		if len(v.SetValue) >= previewMaxItems+50 {
+			t.Errorf("SetValue length = %d, want fewer than the full set", len(v.SetValue))
+		}
+		if !v.Truncated {
+			t.Error("expected Truncated = true")
+		}
+	})
+}
+
+func TestGetValuePreview_ZSet(t *testing.T) {
+	t.Run("small zset", func(t *testing.T) {
+		client, _ := setupTestClient(t)
+		if err := client.ZAdd("z", 1.5, "one"); err != nil {
+			t.Fatalf("ZAdd error: %v", err)
+		}
+
+		v, err := client.GetValuePreview("z")
+		if err != nil {
+			t.Fatalf("GetValuePreview error: %v", err)
+		}
+		if len(v.ZSetValue) != 1 || v.ZSetValue[0].Member != "one" {
+			t.Errorf("ZSetValue = %v, want [one]", v.ZSetValue)
+		}
+		if v.Truncated {
+			t.Error("expected Truncated = false")
+		}
+	})
+
+	t.Run("large zset is truncated", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		for i := 0; i < previewMaxItems+50; i++ {
+			mr.ZAdd("bigz", float64(i), strings.Repeat("m", i%7+1)+string(rune('a'+i%26)))
+		}
+
+		v, err := client.GetValuePreview("bigz")
+		if err != nil {
+			t.Fatalf("GetValuePreview error: %v", err)
+		}
+		if len(v.ZSetValue) != previewMaxItems {
+			t.Errorf("ZSetValue length = %d, want %d", len(v.ZSetValue), previewMaxItems)
+		}
+		if !v.Truncated {
+			t.Error("expected Truncated = true")
+		}
+	})
+}
+
+func TestGetValuePreview_Geo(t *testing.T) {
+	client, _ := setupTestClient(t)
+
+	// 52-bit integer in the geohash range, as produced by GEOADD.
+	if err := client.ZAdd("geo", 3.4e15, "Palermo"); err != nil {
+		t.Fatalf("ZAdd error: %v", err)
+	}
+
+	v, err := client.GetValuePreview("geo")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if v.Type != types.KeyTypeGeo {
+		t.Errorf("Type = %q, want geo", v.Type)
+	}
+	if len(v.GeoValue) != 1 {
+		t.Errorf("GeoValue length = %d, want 1", len(v.GeoValue))
+	}
+}
+
+func TestGetValuePreview_HashCapped(t *testing.T) {
+	client, mr := setupTestClient(t)
+	// miniredis returns every field from a single HSCAN iteration regardless
+	// of COUNT, which exercises the defensive insert cap.
+	for i := 0; i < previewMaxItems+50; i++ {
+		mr.HSet("bighash", fmt.Sprintf("f%03d", i), "v")
+	}
+
+	v, err := client.GetValuePreview("bighash")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if len(v.HashValue) != previewMaxItems {
+		t.Errorf("HashValue length = %d, want cap %d", len(v.HashValue), previewMaxItems)
+	}
+	if !v.Truncated {
+		t.Error("expected Truncated = true")
+	}
+	if v.TotalCount != int64(previewMaxItems+50) {
+		t.Errorf("TotalCount = %d, want %d", v.TotalCount, previewMaxItems+50)
+	}
+}
+
+func TestGetValuePreview_Hash(t *testing.T) {
+	client, mr := setupTestClient(t)
+	mr.HSet("h", "f1", "v1")
+	mr.HSet("h", "f2", "v2")
+
+	v, err := client.GetValuePreview("h")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if len(v.HashValue) != 2 {
+		t.Errorf("HashValue length = %d, want 2", len(v.HashValue))
+	}
+	if v.HashValue["f1"] != "v1" {
+		t.Errorf("HashValue[f1] = %q, want v1", v.HashValue["f1"])
+	}
+	if v.Truncated {
+		t.Error("expected Truncated = false")
+	}
+}
+
+func TestGetValuePreview_Stream(t *testing.T) {
+	t.Run("small stream", func(t *testing.T) {
+		client, _ := setupTestClient(t)
+		if _, err := client.XAdd("str", map[string]any{"k": "v"}); err != nil {
+			t.Fatalf("XAdd error: %v", err)
+		}
+
+		v, err := client.GetValuePreview("str")
+		if err != nil {
+			t.Fatalf("GetValuePreview error: %v", err)
+		}
+		if len(v.StreamValue) != 1 {
+			t.Errorf("StreamValue length = %d, want 1", len(v.StreamValue))
+		}
+		if v.Truncated {
+			t.Error("expected Truncated = false")
+		}
+	})
+
+	t.Run("large stream is truncated", func(t *testing.T) {
+		client, _ := setupTestClient(t)
+		for i := 0; i < previewMaxItems+50; i++ {
+			if _, err := client.XAdd("bigstr", map[string]any{"k": "v"}); err != nil {
+				t.Fatalf("XAdd error: %v", err)
+			}
+		}
+
+		v, err := client.GetValuePreview("bigstr")
+		if err != nil {
+			t.Fatalf("GetValuePreview error: %v", err)
+		}
+		if len(v.StreamValue) != previewMaxItems {
+			t.Errorf("StreamValue length = %d, want %d", len(v.StreamValue), previewMaxItems)
+		}
+		if !v.Truncated {
+			t.Error("expected Truncated = true")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// GetValuePreview — HLL cardinality via the fake server (PFCOUNT succeeds)
+// ---------------------------------------------------------------------------
+
+func TestGetValuePreview_HLLCount(t *testing.T) {
+	srv := newFakeRedisServer(t)
+	srv.setHandler(func(argv []string) string {
+		switch argv[0] {
+		case "TYPE":
+			return "+string\r\n"
+		case "STRLEN":
+			return ":16\r\n"
+		case "GETRANGE":
+			return "$16\r\nHYLL000000000000\r\n"
+		case "PFCOUNT":
+			return ":42\r\n"
+		}
+		return ""
+	})
+	host, port := srv.addr()
+	c := NewClient()
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Disconnect() })
+
+	v, err := c.GetValuePreview("hll")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if v.Type != types.KeyTypeHyperLogLog {
+		t.Errorf("Type = %q, want hyperloglog", v.Type)
+	}
+	if v.HLLCount != 42 {
+		t.Errorf("HLLCount = %d, want 42", v.HLLCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetValuePreview — ReJSON paths via the fake server (miniredis lacks JSON.GET)
+// ---------------------------------------------------------------------------
+
+func TestGetValuePreview_JSON(t *testing.T) {
+	srv := newFakeRedisServer(t)
+	srv.setHandler(func(argv []string) string {
+		switch argv[0] {
+		case "TYPE":
+			return "+ReJSON-RL\r\n"
+		case "JSON.GET":
+			return "$9\r\n[{\"a\":1}]\r\n"
+		}
+		return ""
+	})
+	host, port := srv.addr()
+	c := NewClient()
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Disconnect() })
+
+	v, err := c.GetValuePreview("doc")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if v.JSONValue != `[{"a":1}]` {
+		t.Errorf("JSONValue = %q, want [{\"a\":1}]", v.JSONValue)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetValuePreview — error paths, one per failing command, via the fake server
+// ---------------------------------------------------------------------------
+
+func TestGetValuePreview_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		failCmd  string
+		keyType  string
+		prefetch map[string]string // canned success replies for commands before the failure
+	}{
+		{"type error", "TYPE", "", nil},
+		{"strlen error", "STRLEN", "+string\r\n", nil},
+		{"getrange error", "GETRANGE", "+string\r\n", map[string]string{"STRLEN": ":5\r\n"}},
+		{"llen error", "LLEN", "+list\r\n", nil},
+		{"lrange error", "LRANGE", "+list\r\n", map[string]string{"LLEN": ":5\r\n"}},
+		{"scard error", "SCARD", "+set\r\n", nil},
+		{"sscan error", "SSCAN", "+set\r\n", map[string]string{"SCARD": ":5\r\n"}},
+		{"zcard error", "ZCARD", "+zset\r\n", nil},
+		{"zrange error", "ZRANGE", "+zset\r\n", map[string]string{"ZCARD": ":5\r\n"}},
+		{"hlen error", "HLEN", "+hash\r\n", nil},
+		{"hscan error", "HSCAN", "+hash\r\n", map[string]string{"HLEN": ":5\r\n"}},
+		{"xlen error", "XLEN", "+stream\r\n", nil},
+		{"xrange error", "XRANGE", "+stream\r\n", map[string]string{"XLEN": ":5\r\n"}},
+		{"json get error", "JSON.GET", "+ReJSON-RL\r\n", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newFakeRedisServer(t)
+			srv.setHandler(func(argv []string) string {
+				if argv[0] == tt.failCmd {
+					return "-ERR injected\r\n"
+				}
+				if argv[0] == "TYPE" {
+					return tt.keyType
+				}
+				if resp, ok := tt.prefetch[argv[0]]; ok {
+					return resp
+				}
+				return ""
+			})
+			host, port := srv.addr()
+			c := NewClient()
+			if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port}); err != nil {
+				t.Fatalf("Connect: %v", err)
+			}
+			t.Cleanup(func() { _ = c.Disconnect() })
+
+			if _, err := c.GetValuePreview("k"); err == nil {
+				t.Error("expected error from GetValuePreview")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// previewGeoDetect — GEOPOS error leaves the value as a plain zset
+// ---------------------------------------------------------------------------
+
+func TestGetValuePreview_GeoPosError(t *testing.T) {
+	srv := newFakeRedisServer(t)
+	srv.setHandler(func(argv []string) string {
+		switch argv[0] {
+		case "TYPE":
+			return "+zset\r\n"
+		case "ZCARD":
+			return ":1\r\n"
+		case "ZRANGE":
+			return "*2\r\n$7\r\nPalermo\r\n$16\r\n3400000000000000\r\n"
+		case "GEOPOS":
+			return "-ERR injected\r\n"
+		}
+		return ""
+	})
+	host, port := srv.addr()
+	c := NewClient()
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Disconnect() })
+
+	v, err := c.GetValuePreview("geo")
+	if err != nil {
+		t.Fatalf("GetValuePreview error: %v", err)
+	}
+	if v.Type != types.KeyTypeZSet {
+		t.Errorf("Type = %q, want zset when GEOPOS fails", v.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks: the fetch performed when a key is selected in the keys list.
+// Before GetValuePreview this ran GetValue, pulling entire collections
+// (LRANGE 0 -1, HGETALL, SMEMBERS, ZRANGE 0 -1) for a screenful of preview.
+// ---------------------------------------------------------------------------
+
+func BenchmarkPreviewFetch(b *testing.B) {
+	b.Run("hash_50k_fields", func(b *testing.B) {
+		client, mr := setupBenchClient(b)
+		for i := 0; i < 50_000; i++ {
+			mr.HSet("bighash", fmt.Sprintf("field:%06d", i), strings.Repeat("v", 64))
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := client.GetValuePreview("bighash"); err != nil {
+				b.Fatalf("preview fetch: %v", err)
+			}
+		}
+	})
+
+	b.Run("list_100k_items", func(b *testing.B) {
+		client, mr := setupBenchClient(b)
+		item := strings.Repeat("v", 64)
+		for i := 0; i < 100_000; i++ {
+			mr.RPush("biglist", item)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := client.GetValuePreview("biglist"); err != nil {
+				b.Fatalf("preview fetch: %v", err)
+			}
+		}
+	})
+
+	b.Run("zset_50k_members", func(b *testing.B) {
+		client, mr := setupBenchClient(b)
+		for i := 0; i < 50_000; i++ {
+			mr.ZAdd("bigzset", float64(i), fmt.Sprintf("member:%06d", i))
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := client.GetValuePreview("bigzset"); err != nil {
+				b.Fatalf("preview fetch: %v", err)
+			}
+		}
+	})
+
+	b.Run("string_8mb", func(b *testing.B) {
+		client, mr := setupBenchClient(b)
+		mr.Set("bigstring", strings.Repeat("x", 8*1024*1024))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := client.GetValuePreview("bigstring"); err != nil {
+				b.Fatalf("preview fetch: %v", err)
+			}
+		}
+	})
+}

--- a/internal/redis/preview_test.go
+++ b/internal/redis/preview_test.go
@@ -560,3 +560,44 @@ func BenchmarkPreviewFetch(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkCompareListFetch(b *testing.B) {
+	client, mr := setupBenchClient(b)
+	item := strings.Repeat("v", 64)
+	for i := 0; i < 100_000; i++ {
+		mr.RPush("biglist", item)
+	}
+	b.Run("GetValue_full", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := client.GetValue("biglist"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("GetValuePreview_bounded", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := client.GetValuePreview("biglist"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkCompareStringFetch(b *testing.B) {
+	client, mr := setupBenchClient(b)
+	mr.Set("bigstring", strings.Repeat("x", 8*1024*1024))
+	b.Run("GetValue_full", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := client.GetValue("bigstring"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("GetValuePreview_bounded", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := client.GetValuePreview("bigstring"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -70,6 +70,7 @@ type RedisService interface {
 	ScanKeysWithRegex(regexPattern string, maxKeys int) ([]types.RedisKey, error)
 	FuzzySearchKeys(searchTerm string, maxKeys int) ([]types.RedisKey, error)
 	GetValue(key string) (types.RedisValue, error)
+	GetValuePreview(key string) (types.RedisValue, error)
 	DeleteKey(key string) error
 	DeleteKeys(keys ...string) (int64, error)
 	BulkDelete(pattern string) (int, error)

--- a/internal/testutil/mock_redis.go
+++ b/internal/testutil/mock_redis.go
@@ -80,6 +80,12 @@ func (m *MockRedisClient) GetValue(key string) (types.RedisValue, error) {
 	return value, nil
 }
 
+// GetValuePreview returns the stored value like GetValue; the mock does not
+// simulate truncation.
+func (m *MockRedisClient) GetValuePreview(key string) (types.RedisValue, error) {
+	return m.GetValue(key)
+}
+
 // ScanKeys returns keys matching a pattern from the mock store.
 func (m *MockRedisClient) ScanKeys(pattern string, cursor uint64, count int64) ([]types.RedisKey, uint64, error) {
 	if !m.connected {

--- a/internal/testutil/mock_redis_test.go
+++ b/internal/testutil/mock_redis_test.go
@@ -79,6 +79,19 @@ func TestMockRedisClient_Connected(t *testing.T) {
 		}
 	})
 
+	t.Run("GetValuePreview returns stored value", func(t *testing.T) {
+		val := types.RedisValue{Type: types.KeyTypeString, StringValue: "preview"}
+		m.SetKey("pvkey", val, types.KeyTypeString, 0)
+
+		got, err := m.GetValuePreview("pvkey")
+		if err != nil {
+			t.Fatalf("GetValuePreview error: %v", err)
+		}
+		if got.StringValue != "preview" {
+			t.Errorf("StringValue = %q, want %q", got.StringValue, "preview")
+		}
+	})
+
 	t.Run("ScanKeys with pattern", func(t *testing.T) {
 		m.SetKey("user:1", types.RedisValue{}, types.KeyTypeString, 0)
 		m.SetKey("user:2", types.RedisValue{}, types.KeyTypeString, 0)

--- a/internal/types/redis.go
+++ b/internal/types/redis.go
@@ -49,6 +49,8 @@ type RedisValue struct {
 	// RawSize / DecodedSize track original vs decompressed payload sizes.
 	RawSize     int
 	DecodedSize int
+	Truncated   bool  // value is a bounded preview, not the full value
+	TotalCount  int64 // full length/cardinality when Truncated is set
 }
 
 // GeoMember represents a geospatial member with coordinates

--- a/internal/ui/gaps_test.go
+++ b/internal/ui/gaps_test.go
@@ -274,33 +274,6 @@ func TestSanitizeBinaryString_HighRange(t *testing.T) {
 
 // ---- colorizeJSON various paths ----
 
-func TestColorizeJSON_VariousPaths(t *testing.T) {
-	inputs := []string{
-		`{"key":"value","num":42,"neg":-3.14,"bool":true,"false":false,"null":null,"arr":[1,2,3]}`,
-		`{"escaped":"he said \"hi\""}`,
-		`{"exp":1.5e10}`,
-		`[1, 2, 3]`,
-		`{`, // unclosed
-		`"just a string"`,
-	}
-	for _, in := range inputs {
-		_ = colorizeJSON(in)
-	}
-}
-
-// ---- isInArrayContext with nested brackets ----
-
-func TestIsInArrayContext_NestedBrackets(t *testing.T) {
-	// Forces bracketCount > 0 path: position after a nested ] that needs bracketCount decrement
-	_ = isInArrayContext(`[[1]]`, 3) // inside outer array, after inner close
-	// Forces braceCount > 0 path
-	_ = isInArrayContext(`[{}]`, 2) // inside array, after brace close
-	_ = isInArrayContext(`[]`, 0)   // array start
-	_ = isInArrayContext(`{}`, 0)   // object start
-}
-
-// ---- parseLogEntry non-RFC3339 time fallback ----
-
 func TestParseLogEntry_NonRFC3339Time(t *testing.T) {
 	input := `{"time":"not-a-timestamp","level":"INFO","msg":"hello"}`
 	entry := parseLogEntry(input)
@@ -386,21 +359,6 @@ func TestColorizeJSON_EscapedInString(t *testing.T) {
 }
 
 // ---- colorizeJSON unterminated quote fallthrough ----
-
-func TestColorizeJSON_UnterminatedQuote(t *testing.T) {
-	_ = colorizeJSON(`{"unterm`)
-	_ = colorizeJSON(`"`)
-}
-
-// ---- isInArrayContext bare value (no brackets) returns false ----
-
-func TestIsInArrayContext_BareValue(t *testing.T) {
-	if isInArrayContext("123", 2) {
-		t.Error("expected false for bare value")
-	}
-}
-
-// ---- Pattern debounce cmd inner closure ----
 
 func TestHandleKeysScreen_DebounceClosureFires(t *testing.T) {
 	m, _, _ := newTestModel(t)

--- a/internal/ui/messages_keys.go
+++ b/internal/ui/messages_keys.go
@@ -40,6 +40,7 @@ func (m Model) handleKeyValueLoadedMsg(msg types.KeyValueLoadedMsg) (tea.Model, 
 		m.StatusMsg = "Error: " + msg.Err.Error()
 	} else {
 		m.CurrentValue = msg.Value
+		m.DetailRendered = buildDetailValueContent(msg.Value)
 		m.DetailScroll = 0
 		m.DetailCursor = 0
 		// On-demand type resolution: fill in type if it was not fetched during scan,
@@ -60,6 +61,16 @@ func (m Model) handleKeyPreviewLoadedMsg(msg types.KeyPreviewLoadedMsg) (tea.Mod
 	if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys) && m.Keys[m.SelectedKeyIdx].Key == msg.Key {
 		m.PreviewKey = msg.Key
 		m.PreviewValue = msg.Value
+		// Pre-format string/JSON/protobuf previews once — must not run per frame.
+		m.PreviewRendered = ""
+		switch msg.Value.Type {
+		case types.KeyTypeString:
+			m.PreviewRendered = formatPossibleJSON(msg.Value.StringValue)
+		case types.KeyTypeJSON:
+			m.PreviewRendered = formatPossibleJSON(msg.Value.JSONValue)
+		case types.KeyTypeProtobuf:
+			m.PreviewRendered = formatProtobufValue(msg.Value)
+		}
 		// On-demand type resolution: fill in type if it was not fetched during scan,
 		// or update when GetValue detected a subtype (e.g. string→hyperloglog)
 		if msg.Value.Type != "" && m.Keys[m.SelectedKeyIdx].Type != msg.Value.Type {

--- a/internal/ui/messages_keys_test.go
+++ b/internal/ui/messages_keys_test.go
@@ -382,3 +382,27 @@ func TestHandleBatchTTLSetMsg(t *testing.T) {
 		}
 	})
 }
+
+func TestHandleKeyPreviewLoadedMsg_CachedTypes(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.Keys = []types.RedisKey{{Key: "s", Type: types.KeyTypeString}}
+	m.SelectedKeyIdx = 0
+	msg := types.KeyPreviewLoadedMsg{Key: "s", Value: types.RedisValue{Type: types.KeyTypeString, StringValue: `{"a":1}`}}
+	got, _ := m.handleKeyPreviewLoadedMsg(msg)
+	model := got.(Model)
+	if model.PreviewRendered == "" {
+		t.Error("expected PreviewRendered for string JSON")
+	}
+	msg = types.KeyPreviewLoadedMsg{Key: "s", Value: types.RedisValue{Type: types.KeyTypeJSON, JSONValue: `{"b":2}`}}
+	got, _ = model.handleKeyPreviewLoadedMsg(msg)
+	model = got.(Model)
+	if model.PreviewRendered == "" {
+		t.Error("expected PreviewRendered for JSON")
+	}
+	msg = types.KeyPreviewLoadedMsg{Key: "s", Value: types.RedisValue{Type: types.KeyTypeProtobuf, DecodedValue: "1: 1\n", DecodedFormat: "protobuf"}}
+	got, _ = model.handleKeyPreviewLoadedMsg(msg)
+	model = got.(Model)
+	if model.PreviewRendered == "" || !strings.Contains(model.PreviewRendered, "protobuf") {
+		t.Errorf("expected protobuf preview render, got %q", model.PreviewRendered)
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -151,6 +151,11 @@ type Model struct {
 	DetailScroll  int // viewport top line in the detail value body
 	DetailCursor  int // selected line in the detail value body (blue band)
 
+	// Cached formatted renders, computed once when a value is loaded so the
+	// 1 Hz TTL tick does not re-pretty-print / re-colorize large payloads.
+	DetailRendered  string
+	PreviewRendered string
+
 	// Live metrics dashboard
 	LiveMetrics       *types.LiveMetrics
 	LiveMetricsActive bool

--- a/internal/ui/view_keys_detail.go
+++ b/internal/ui/view_keys_detail.go
@@ -72,7 +72,7 @@ func (m Model) viewKeyDetail() string {
 		Padding(1, 2).
 		Width(boxWidth)
 
-	valueStr := m.detailValuePlainString()
+	valueStr := m.detailValueContent()
 	// Wrap to the box content width so scroll line counts match what is painted.
 	valueLines := wrapPlainLines(strings.Split(valueStr, "\n"), contentWidth)
 	maxVisible := detailMaxVisible(m.Height)
@@ -128,7 +128,7 @@ func (m Model) viewKeyDetail() string {
 }
 
 func (m Model) detailContentLines() int {
-	lines := wrapPlainLines(strings.Split(m.detailValuePlainString(), "\n"), detailContentWidth(detailBoxWidth(m.Width)))
+	lines := wrapPlainLines(strings.Split(m.detailValueContent(), "\n"), detailContentWidth(detailBoxWidth(m.Width)))
 	return len(lines)
 }
 
@@ -137,54 +137,67 @@ func (m Model) detailLastLine() int {
 	return max(m.detailContentLines()-1, 0)
 }
 
+// detailValueContent returns the formatted value block, using the per-load cache when set.
+func (m Model) detailValueContent() string {
+	if m.DetailRendered != "" {
+		return m.DetailRendered
+	}
+	return buildDetailValueContent(m.CurrentValue)
+}
+
 // detailValueString returns the detail body used by tests and line counting.
 func (m Model) detailValueString() string {
-	return m.detailValuePlainString()
+	return m.detailValueContent()
 }
 
 // detailValuePlainString builds the unstyled value body for the detail pane.
 func (m Model) detailValuePlainString() string {
+	return buildDetailValueContent(m.CurrentValue)
+}
+
+// buildDetailValueContent formats a Redis value for the key detail view.
+func buildDetailValueContent(value types.RedisValue) string {
 	var vc strings.Builder
-	switch m.CurrentValue.Type {
+	switch value.Type {
 	case types.KeyTypeString:
-		vc.WriteString(formatPossibleJSON(m.CurrentValue.StringValue))
+		vc.WriteString(formatPossibleJSON(value.StringValue))
 	case types.KeyTypeList:
-		if len(m.CurrentValue.ListValue) == 0 {
+		if len(value.ListValue) == 0 {
 			vc.WriteString("(empty list)")
 		} else {
-			for i, v := range m.CurrentValue.ListValue {
+			for i, v := range value.ListValue {
 				fmt.Fprintf(&vc, "%d. %s\n", i, formatPossibleJSON(v))
 			}
 		}
 	case types.KeyTypeSet:
-		if len(m.CurrentValue.SetValue) == 0 {
+		if len(value.SetValue) == 0 {
 			vc.WriteString("(empty set)")
 		} else {
-			for _, v := range m.CurrentValue.SetValue {
+			for _, v := range value.SetValue {
 				vc.WriteString("• ")
 				vc.WriteString(formatPossibleJSON(v))
 				vc.WriteString("\n")
 			}
 		}
 	case types.KeyTypeZSet:
-		if len(m.CurrentValue.ZSetValue) == 0 {
+		if len(value.ZSetValue) == 0 {
 			vc.WriteString("(empty sorted set)")
 		} else {
-			for _, v := range m.CurrentValue.ZSetValue {
+			for _, v := range value.ZSetValue {
 				fmt.Fprintf(&vc, "%.2f: %s\n", v.Score, formatPossibleJSON(v.Member))
 			}
 		}
 	case types.KeyTypeHash:
-		if len(m.CurrentValue.HashValue) == 0 {
+		if len(value.HashValue) == 0 {
 			vc.WriteString("(empty hash)")
 		} else {
-			hashKeys := make([]string, 0, len(m.CurrentValue.HashValue))
-			for k := range m.CurrentValue.HashValue {
+			hashKeys := make([]string, 0, len(value.HashValue))
+			for k := range value.HashValue {
 				hashKeys = append(hashKeys, k)
 			}
 			sort.Strings(hashKeys)
 			for _, k := range hashKeys {
-				v := m.CurrentValue.HashValue[k]
+				v := value.HashValue[k]
 				formattedValue := formatPossibleJSON(v)
 				if strings.Contains(formattedValue, "\n") {
 					fmt.Fprintf(&vc, "◆ %s:\n%s\n", k, formattedValue)
@@ -194,10 +207,10 @@ func (m Model) detailValuePlainString() string {
 			}
 		}
 	case types.KeyTypeStream:
-		if len(m.CurrentValue.StreamValue) == 0 {
+		if len(value.StreamValue) == 0 {
 			vc.WriteString("(empty stream)")
 		} else {
-			for _, entry := range m.CurrentValue.StreamValue {
+			for _, entry := range value.StreamValue {
 				jsonBytes, err := json.MarshalIndent(entry.Fields, "", "  ")
 				if err == nil {
 					fmt.Fprintf(&vc, "%s:\n%s\n", entry.ID, string(jsonBytes))
@@ -211,29 +224,29 @@ func (m Model) detailValuePlainString() string {
 			}
 		}
 	case types.KeyTypeJSON:
-		vc.WriteString(formatPossibleJSON(m.CurrentValue.JSONValue))
+		vc.WriteString(formatPossibleJSON(value.JSONValue))
 	case types.KeyTypeHyperLogLog:
-		fmt.Fprintf(&vc, "Estimated cardinality: %d", m.CurrentValue.HLLCount)
+		fmt.Fprintf(&vc, "Estimated cardinality: %d", value.HLLCount)
 	case types.KeyTypeProtobuf:
-		vc.WriteString(formatProtobufValue(m.CurrentValue))
+		vc.WriteString(formatProtobufValue(value))
 	case types.KeyTypeBitmap:
-		fmt.Fprintf(&vc, "Bit count: %d\n\n", m.CurrentValue.BitCount)
-		if len(m.CurrentValue.BitPositions) > 0 {
+		fmt.Fprintf(&vc, "Bit count: %d\n\n", value.BitCount)
+		if len(value.BitPositions) > 0 {
 			vc.WriteString("Set positions:\n")
-			for _, pos := range m.CurrentValue.BitPositions {
+			for _, pos := range value.BitPositions {
 				fmt.Fprintf(&vc, "  bit %d = 1\n", pos)
 			}
-			if m.CurrentValue.BitCount > int64(len(m.CurrentValue.BitPositions)) {
-				fmt.Fprintf(&vc, "  … and %d more\n", m.CurrentValue.BitCount-int64(len(m.CurrentValue.BitPositions)))
+			if value.BitCount > int64(len(value.BitPositions)) {
+				fmt.Fprintf(&vc, "  … and %d more\n", value.BitCount-int64(len(value.BitPositions)))
 			}
 		} else {
 			vc.WriteString("(all bits are 0)")
 		}
 	case types.KeyTypeGeo:
-		if len(m.CurrentValue.GeoValue) == 0 {
+		if len(value.GeoValue) == 0 {
 			vc.WriteString("(empty geo set)")
 		} else {
-			for _, g := range m.CurrentValue.GeoValue {
+			for _, g := range value.GeoValue {
 				fmt.Fprintf(&vc, "%s  (%.6f, %.6f)\n", g.Name, g.Longitude, g.Latitude)
 			}
 		}

--- a/internal/ui/view_keys_preview.go
+++ b/internal/ui/view_keys_preview.go
@@ -93,7 +93,20 @@ func (m Model) buildPreviewPanel(width int) string {
 	valueContent := m.formatPreviewValue(width, maxLines)
 	b.WriteString(valueContent)
 
+	if m.PreviewValue.Truncated {
+		b.WriteString("\n")
+		b.WriteString(dimStyle.Render(fmt.Sprintf("(preview — %d total)", m.PreviewValue.TotalCount)))
+	}
+
 	return b.String()
+}
+
+// previewFormatted returns the pre-rendered preview content when cached.
+func (m Model) previewFormatted(raw string) string {
+	if m.PreviewRendered != "" {
+		return m.PreviewRendered
+	}
+	return formatPossibleJSON(raw)
 }
 
 func (m Model) formatPreviewValue(maxWidth, maxLines int) string {
@@ -104,8 +117,7 @@ func (m Model) formatPreviewValue(maxWidth, maxLines int) string {
 
 	switch m.PreviewValue.Type {
 	case types.KeyTypeString:
-		value := m.PreviewValue.StringValue
-		formatted := formatPossibleJSON(value)
+		formatted := m.previewFormatted(m.PreviewValue.StringValue)
 
 		// Split into lines and limit
 		valueLines := strings.Split(formatted, "\n")
@@ -250,8 +262,7 @@ func (m Model) formatPreviewValue(maxWidth, maxLines int) string {
 		}
 
 	case types.KeyTypeJSON:
-		value := m.PreviewValue.JSONValue
-		formatted := formatPossibleJSON(value)
+		formatted := m.previewFormatted(m.PreviewValue.JSONValue)
 
 		valueLines := strings.Split(formatted, "\n")
 		for i, line := range valueLines {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -678,5 +679,56 @@ func TestPreviewFormattedAndTruncated(t *testing.T) {
 	out := m.buildPreviewPanel(40)
 	if !strings.Contains(out, "99") {
 		t.Errorf("expected truncated total, got %q", out)
+	}
+}
+
+// BenchmarkViewKeyDetailLargeJSON measures one cached detail render frame.
+func BenchmarkViewKeyDetailLargeJSON(b *testing.B) {
+	var sb strings.Builder
+	sb.WriteString(`{"items": [`)
+	for i := 0; i < 5000; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`{"id": 12345, "name": "some-item-name", "active": true, "score": 98.6, "tag": null}`)
+	}
+	sb.WriteString(`]}`)
+
+	m := NewModel()
+	m.Width = 120
+	m.Height = 40
+	m.CurrentKey = &types.RedisKey{Key: "big:json", Type: types.KeyTypeString}
+	m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: sb.String()}
+	m.DetailRendered = buildDetailValueContent(m.CurrentValue)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.viewKeyDetail()
+	}
+}
+
+// BenchmarkViewKeyDetailProtobuf measures a cached detail frame for a large
+// decoded protobuf body (typical after s2 decompress + decode_raw).
+func BenchmarkViewKeyDetailProtobuf(b *testing.B) {
+	var body strings.Builder
+	for i := 0; i < 2000; i++ {
+		fmt.Fprintf(&body, "5: {\n  1: \"cat:%d\"\n  2: \"Category Name %d\"\n  4: 1\n  5: 1\n  6: 1\n  7: %d\n}\n", i, i, i)
+	}
+	m := NewModel()
+	m.Width = 120
+	m.Height = 40
+	m.CurrentKey = &types.RedisKey{Key: "menu:v4:demo", Type: types.KeyTypeProtobuf}
+	m.CurrentValue = types.RedisValue{
+		Type:          types.KeyTypeProtobuf,
+		DecodedFormat: "s2+protobuf",
+		DecodedValue:  body.String(),
+		RawSize:       200_000,
+		DecodedSize:   800_000,
+	}
+	m.DetailRendered = buildDetailValueContent(m.CurrentValue)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.viewKeyDetail()
 	}
 }

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -646,3 +646,37 @@ func TestViewAddKey(t *testing.T) {
 		assertNonEmpty(t, "narrow", m.viewAddKey())
 	})
 }
+
+func TestDetailValueContentCache(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: "hi"}
+	m.DetailRendered = ""
+	if got := m.detailValueContent(); got == "" {
+		t.Error("expected uncached content")
+	}
+	_ = m.detailValuePlainString()
+	m.DetailRendered = "CACHED"
+	if m.detailValueContent() != "CACHED" {
+		t.Error("expected cache hit")
+	}
+}
+
+func TestPreviewFormattedAndTruncated(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.Keys = []types.RedisKey{{Key: "k", Type: types.KeyTypeList}}
+	m.SelectedKeyIdx = 0
+	m.PreviewKey = "k"
+	m.PreviewValue = types.RedisValue{Type: types.KeyTypeList, ListValue: []string{"a"}, Truncated: true, TotalCount: 99}
+	m.PreviewRendered = ""
+	if m.previewFormatted("x") == "" {
+		t.Error("fallback format")
+	}
+	m.PreviewRendered = "PRE"
+	if m.previewFormatted("x") != "PRE" {
+		t.Error("cache hit")
+	}
+	out := m.buildPreviewPanel(40)
+	if !strings.Contains(out, "99") {
+		t.Errorf("expected truncated total, got %q", out)
+	}
+}

--- a/internal/ui/view_utils.go
+++ b/internal/ui/view_utils.go
@@ -157,117 +157,105 @@ func formatPossibleJSON(s string) string {
 	return s
 }
 
-// Shared syntax-highlight styles (jq-style).
+// jq-style JSON highlight styles, allocated once instead of per call.
 var (
-	jsonKeyStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))  // Blue for keys / field numbers
-	stringValueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("34"))  // Green for strings
-	jsonNumberStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("33"))  // Yellow for numbers
-	boolStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("35"))  // Magenta for booleans
-	jsonNullStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("90"))  // Gray for null
-	bracketStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))  // White for brackets
+	jsonKeyStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("39")) // Blue for keys
+	jsonStringStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("34")) // Green for string values
+	jsonNumberStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("33")) // Yellow for numbers
+	jsonBoolStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("35")) // Magenta for booleans
+	jsonNullStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("90")) // Gray for null
+	jsonBracketStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15")) // White for brackets
 )
 
-// colorizeJSON adds jq-style syntax highlighting to JSON
+
+// Aliases used by protobuf highlighting and other callers.
+var (
+	stringValueStyle = jsonStringStyle
+	boolStyle        = jsonBoolStyle
+	bracketStyle     = jsonBracketStyle
+)
+
+// colorizeJSON adds jq-style syntax highlighting to JSON. It runs in a single
+// forward pass, tracking object/array nesting with a stack so deciding
+// key-vs-value context is O(1) per string token.
 func colorizeJSON(s string) string {
 	var result strings.Builder
-	inString := false
-	escaped := false
-	isKey := false
 	afterColon := false
+	// nesting stack: '{' for objects, '[' for arrays
+	var stack []byte
+
+	inArray := func() bool {
+		return len(stack) > 0 && stack[len(stack)-1] == '['
+	}
 
 	i := 0
 	for i < len(s) {
 		c := s[i]
 
-		if escaped {
-			result.WriteByte(c)
-			escaped = false
-			i++
-			continue
-		}
-
-		if c == '\\' && inString {
-			result.WriteByte(c)
-			escaped = true
-			i++
-			continue
-		}
-
 		if c == '"' {
-			if !inString {
-				inString = true
-				isKey = !afterColon && !isAfterArrayStart(s, i)
-				afterColon = false
-				end := findStringEnd(s, i+1)
-				if end > i {
-					str := s[i : end+1]
-					if isKey {
-						result.WriteString(jsonKeyStyle.Render(str))
-					} else {
-						result.WriteString(stringValueStyle.Render(str))
-					}
-					i = end + 1
-					inString = false
-					continue
+			end := findStringEnd(s, i+1)
+			if end > i {
+				str := s[i : end+1]
+				if !afterColon && !inArray() {
+					result.WriteString(jsonKeyStyle.Render(str))
+				} else {
+					result.WriteString(jsonStringStyle.Render(str))
 				}
+				afterColon = false
+				i = end + 1
+				continue
 			}
+			// Unterminated string: keep the quote and fall through to
+			// plain-byte handling for the remainder.
+			result.WriteByte(c)
 			i++
 			continue
 		}
 
-		if !inString {
-			if c == ':' {
-				result.WriteByte(c)
-				afterColon = true
-				i++
-				continue
+		switch {
+		case c == ':':
+			result.WriteByte(c)
+			afterColon = true
+			i++
+		case c == ',' || c == '\n':
+			result.WriteByte(c)
+			afterColon = false
+			i++
+		case c == '{' || c == '[':
+			result.WriteString(jsonBracketStyle.Render(string(c)))
+			stack = append(stack, c)
+			afterColon = false
+			i++
+		case c == '}' || c == ']':
+			result.WriteString(jsonBracketStyle.Render(string(c)))
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
 			}
-			if c == ',' || c == '\n' {
-				result.WriteByte(c)
-				afterColon = false
-				i++
-				continue
+			i++
+		case (c >= '0' && c <= '9') || c == '-':
+			end := i
+			for end < len(s) && (s[end] >= '0' && s[end] <= '9' || s[end] == '.' || s[end] == '-' || s[end] == 'e' || s[end] == 'E' || s[end] == '+') {
+				end++
 			}
-			if c == '{' || c == '}' || c == '[' || c == ']' {
-				result.WriteString(bracketStyle.Render(string(c)))
-				if c == '[' || c == '{' {
-					afterColon = false
-				}
-				i++
-				continue
-			}
-			if (c >= '0' && c <= '9') || c == '-' {
-				end := i
-				for end < len(s) && (s[end] >= '0' && s[end] <= '9' || s[end] == '.' || s[end] == '-' || s[end] == 'e' || s[end] == 'E' || s[end] == '+') {
-					end++
-				}
-				result.WriteString(jsonNumberStyle.Render(s[i:end]))
-				i = end
-				afterColon = false
-				continue
-			}
-			if strings.HasPrefix(s[i:], "true") {
-				result.WriteString(boolStyle.Render("true"))
-				i += 4
-				afterColon = false
-				continue
-			}
-			if strings.HasPrefix(s[i:], "false") {
-				result.WriteString(boolStyle.Render("false"))
-				i += 5
-				afterColon = false
-				continue
-			}
-			if strings.HasPrefix(s[i:], "null") {
-				result.WriteString(jsonNullStyle.Render("null"))
-				i += 4
-				afterColon = false
-				continue
-			}
+			result.WriteString(jsonNumberStyle.Render(s[i:end]))
+			i = end
+			afterColon = false
+		case strings.HasPrefix(s[i:], "true"):
+			result.WriteString(jsonBoolStyle.Render("true"))
+			i += 4
+			afterColon = false
+		case strings.HasPrefix(s[i:], "false"):
+			result.WriteString(jsonBoolStyle.Render("false"))
+			i += 5
+			afterColon = false
+		case strings.HasPrefix(s[i:], "null"):
+			result.WriteString(jsonNullStyle.Render("null"))
+			i += 4
+			afterColon = false
+		default:
+			result.WriteByte(c)
+			i++
 		}
-
-		result.WriteByte(c)
-		i++
 	}
 
 	return result.String()
@@ -285,49 +273,6 @@ func findStringEnd(s string, start int) int {
 		}
 	}
 	return -1
-}
-
-// isAfterArrayStart checks if we're inside an array (value context)
-func isAfterArrayStart(s string, pos int) bool {
-	for i := pos - 1; i >= 0; i-- {
-		c := s[i]
-		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
-			continue
-		}
-		if c == '[' || c == ',' {
-			return isInArrayContext(s, i)
-		}
-		return false
-	}
-	return false
-}
-
-// isInArrayContext checks if position is within an array
-func isInArrayContext(s string, pos int) bool {
-	bracketCount := 0
-	braceCount := 0
-	for i := pos; i >= 0; i-- {
-		c := s[i]
-		switch c {
-		case ']':
-			bracketCount++
-		case '[':
-			if bracketCount > 0 {
-				bracketCount--
-			} else {
-				return true
-			}
-		case '}':
-			braceCount++
-		case '{':
-			if braceCount > 0 {
-				braceCount--
-			} else {
-				return false
-			}
-		}
-	}
-	return false
 }
 
 // colorizeProtobuf highlights schema-less protobuf text (field numbers, strings, numbers, braces).

--- a/internal/ui/view_utils_test.go
+++ b/internal/ui/view_utils_test.go
@@ -361,54 +361,6 @@ func TestFindStringEnd(t *testing.T) {
 	}
 }
 
-func TestIsAfterArrayStart(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		pos      int
-		expected bool
-	}{
-		{"after open bracket", `["hello"]`, 1, true},
-		{"after comma in array", `["a", "b"]`, 5, true},
-		{"after open brace", `{"key": "val"}`, 8, false},
-		{"after colon", `{"key": "val"}`, 8, false},
-		{"beginning of string", `"hello"`, 0, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isAfterArrayStart(tt.input, tt.pos)
-			if got != tt.expected {
-				t.Errorf("isAfterArrayStart(%q, %d) = %v, want %v", tt.input, tt.pos, got, tt.expected)
-			}
-		})
-	}
-}
-
-func TestIsInArrayContext(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		pos      int
-		expected bool
-	}{
-		{"inside array", `["a", "b"]`, 5, true},
-		{"inside object", `{"a": "b"}`, 5, false},
-		{"nested array in object", `{"k": ["a", "b"]}`, 10, true},
-		{"nested object in array", `[{"a": "b"}]`, 5, false},
-		{"at array start", `["a"]`, 0, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isInArrayContext(tt.input, tt.pos)
-			if got != tt.expected {
-				t.Errorf("isInArrayContext(%q, %d) = %v, want %v", tt.input, tt.pos, got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestFormatPossibleJSON(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -464,5 +416,20 @@ func TestFormatPossibleJSON_NoPanic(t *testing.T) {
 			// Should not panic
 			_ = formatPossibleJSON(input)
 		})
+	}
+}
+
+func TestColorizeJSON_LinearPaths(t *testing.T) {
+	cases := []string{
+		`{"a":1,"b":true,"c":null,"d":false}`,
+		`[1,2,"x"]`,
+		`{"k":"unterminated`,
+		`{"n":-1.5e+2}`,
+	}
+	for _, c := range cases {
+		out := colorizeJSON(c)
+		if out == "" {
+			t.Errorf("empty colorize for %q", c)
+		}
 	}
 }

--- a/internal/ui/view_utils_test.go
+++ b/internal/ui/view_utils_test.go
@@ -433,3 +433,20 @@ func TestColorizeJSON_LinearPaths(t *testing.T) {
 		}
 	}
 }
+
+// BenchmarkColorizeJSONLarge guards against colorizeJSON regressing to
+// super-linear behavior on large JSON arrays of strings.
+func BenchmarkColorizeJSONLarge(b *testing.B) {
+	var sb strings.Builder
+	sb.WriteString("[\n")
+	for i := 0; i < 20000; i++ {
+		sb.WriteString("  \"element-number-with-some-padding-0123456789\",\n")
+	}
+	sb.WriteString("  \"last\"\n]")
+	s := sb.String()
+	b.SetBytes(int64(len(s)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = colorizeJSON(s)
+	}
+}


### PR DESCRIPTION
## Context

Selecting large keys and scanning string-heavy keyspaces could pull entire Redis values for a screenful of UI. This bounds those paths, caches formatted renders, and keeps protobuf (s2 + wire decode) on the hot path.

## Demo

```bash
make build && ./bin/redis-tui -h localhost -p 6379
make bench
```

## Changes

- SCAN subtype detection: pipelined `GETRANGE` (256 B) instead of full `GET`
- `GetValuePreview`: ≤100 collection members, ≤64 KB strings; `Truncated` / `TotalCount` in UI
- Linear `colorizeJSON` + cache detail/preview renders on load
- Bitmap bit-position cap at 1024
- Benchmarks for list/string/hash/zset previews, scan, JSON colorize, **and s2+protobuf**

## Measured (this branch, Apple M3 Pro, miniredis, `-benchtime=5x -count=3`, median-ish)

| Path | Result |
|------|--------|
| SCAN 100 keys × 512 KB strings | **~1.9 ms** |
| SCAN 50 s2+protobuf menus | **~1.2 ms** |
| `GetValue` large s2+protobuf (full decode) | **~0.67 ms** |
| `GetValuePreview` s2+protobuf | **~0.12 ms** |
| List 100k items: full `GetValue` | **~14 ms** |
| List 100k items: `GetValuePreview` | **~0.10 ms** (~140×) |
| String 8 MB: full `GetValue` | **~15 ms** |
| String 8 MB: `GetValuePreview` | **~0.09 ms** (~170×) |
| `colorizeJSON` ~1 MB array | **~41 ms** |
| Detail frame, large cached JSON | **~6 ms** |
| Detail frame, large cached protobuf text | **~1.2 ms** |

Protobuf stays in the sub‑ms to low‑ms range for scan/decode/preview/detail. Hash preview on miniredis is still heavier (~20 ms for 50k fields) because miniredis does not page `HSCAN` the way real Redis does.

## Testing

- `go test -race ./...`
- `make test-cover-check`
- `make bench`

## Notes

- Rebased onto `main` (protobuf decode included). Incomplete large binary SCAN probes stay typed as `string` until open so s2/protobuf is not mislabeled `bitmap`.
