### PR TITLE
feat: decode s2+protobuf Redis values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bin/
 redis.test
 coverage.out
 coverage.html
+
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ go install github.com/davidbudnick/redis-tui@latest
 ### Browsing and Editing
 
 - **Key browser** with pattern filtering, regex, and fuzzy search
-- **All data types** — strings, lists, sets, sorted sets, hashes, streams, JSON (RedisJSON), HyperLogLog, bitmaps, and geospatial
+- **All data types** — strings, lists, sets, sorted sets, hashes, streams, JSON (RedisJSON), HyperLogLog, bitmaps, geospatial, and protobuf (including s2-compressed wire payloads)
 - **Inline value editor** for editing string and JSON values
 - **Tree view** for hierarchical key navigation
 - **Favorites and recent keys** for quick access

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/alicebob/miniredis/v2 v2.38.0
+	github.com/klauspost/compress v1.19.1
 	github.com/redis/go-redis/v9 v9.21.0
+	google.golang.org/protobuf v1.36.11
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
+github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
@@ -68,5 +70,7 @@ golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/decode/binary.go
+++ b/internal/decode/binary.go
@@ -28,6 +28,13 @@ const (
 	maxDepth = 8
 	// maxFields caps how many fields are rendered per message level.
 	maxFields = 5000
+	// maxFieldNumber is the protobuf wire max field number (2^29 - 1).
+	maxFieldNumber = 536870911
+	// Wire types kept as uint64 so tag bits need no narrowing casts (gosec G115).
+	wireVarint  uint64 = 0
+	wireFixed64 uint64 = 1
+	wireBytes   uint64 = 2
+	wireFixed32 uint64 = 5
 )
 
 // TryBinary attempts s2 decompression then schema-less protobuf decoding.
@@ -80,6 +87,16 @@ func isValidProtobuf(b []byte) bool {
 	return consumeMessage(b) == len(b)
 }
 
+// splitTag extracts field number and wire type from a protobuf tag without narrowing casts.
+func splitTag(tag uint64) (fieldNum, wireType uint64, ok bool) {
+	fieldNum = tag >> 3
+	wireType = tag & 7
+	if fieldNum < 1 || fieldNum > maxFieldNumber {
+		return 0, 0, false
+	}
+	return fieldNum, wireType, true
+}
+
 // consumeMessage returns bytes consumed if b is a valid message, else -1.
 func consumeMessage(b []byte) int {
 	i := 0
@@ -90,19 +107,18 @@ func consumeMessage(b []byte) int {
 			return -1
 		}
 		i += n
-		num := protowire.Number(tag >> 3)
-		wt := protowire.Type(tag & 7)
-		if num < 1 {
+		_, wt, ok := splitTag(tag)
+		if !ok {
 			return -1
 		}
 		switch wt {
-		case protowire.VarintType:
+		case wireVarint:
 			_, n = protowire.ConsumeVarint(b[i:])
-		case protowire.Fixed64Type:
+		case wireFixed64:
 			_, n = protowire.ConsumeFixed64(b[i:])
-		case protowire.BytesType:
+		case wireBytes:
 			_, n = protowire.ConsumeBytes(b[i:])
-		case protowire.Fixed32Type:
+		case wireFixed32:
 			_, n = protowire.ConsumeFixed32(b[i:])
 		default:
 			// Groups (3/4) and unknown wire types are rejected.
@@ -145,23 +161,25 @@ func writeMessage(sb *strings.Builder, b []byte, depth int) {
 		}
 		tag, n := protowire.ConsumeVarint(b[i:])
 		i += n
-		num := protowire.Number(tag >> 3)
-		wt := protowire.Type(tag & 7)
+		num, wt, ok := splitTag(tag)
+		if !ok {
+			return
+		}
 
 		switch wt {
-		case protowire.VarintType:
+		case wireVarint:
 			v, n := protowire.ConsumeVarint(b[i:])
 			i += n
 			fmt.Fprintf(sb, "%s%d: %d\n", indent(depth), num, v)
-		case protowire.Fixed64Type:
+		case wireFixed64:
 			v, n := protowire.ConsumeFixed64(b[i:])
 			i += n
 			fmt.Fprintf(sb, "%s%d: 0x%x\n", indent(depth), num, v)
-		case protowire.BytesType:
+		case wireBytes:
 			v, n := protowire.ConsumeBytes(b[i:])
 			i += n
-			writeBytesField(sb, int(num), v, depth)
-		case protowire.Fixed32Type:
+			writeBytesField(sb, num, v, depth)
+		case wireFixed32:
 			v, n := protowire.ConsumeFixed32(b[i:])
 			i += n
 			fmt.Fprintf(sb, "%s%d: 0x%x\n", indent(depth), num, v)
@@ -171,7 +189,7 @@ func writeMessage(sb *strings.Builder, b []byte, depth int) {
 }
 
 // writeBytesField renders a length-delimited field as string, nested message, or bytes.
-func writeBytesField(sb *strings.Builder, num int, v []byte, depth int) {
+func writeBytesField(sb *strings.Builder, num uint64, v []byte, depth int) {
 	if isPrintableUTF8(v) {
 		fmt.Fprintf(sb, "%s%d: %q\n", indent(depth), num, string(v))
 		return

--- a/internal/decode/binary.go
+++ b/internal/decode/binary.go
@@ -1,0 +1,213 @@
+package decode
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/klauspost/compress/s2"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// Result is a successful decode of binary Redis string payload.
+type Result struct {
+	// Format is a short label such as "protobuf" or "s2+protobuf".
+	Format string
+	// Text is a schema-less pretty-print of the message (protoc --decode_raw style).
+	Text string
+	// RawSize is the original Redis value length in bytes.
+	RawSize int
+	// DecodedSize is the size after decompression (equals RawSize when uncompressed).
+	DecodedSize int
+}
+
+const (
+	// maxDecodeText caps pretty-printed output so huge menus stay usable.
+	maxDecodeText = 64 * 1024
+	// maxDepth limits nested message expansion.
+	maxDepth = 8
+	// maxFields caps how many fields are rendered per message level.
+	maxFields = 5000
+)
+
+// TryBinary attempts s2 decompression then schema-less protobuf decoding.
+func TryBinary(raw []byte) (Result, bool) {
+	if len(raw) == 0 {
+		return Result{}, false
+	}
+
+	if decompressed, err := s2.Decode(nil, raw); err == nil && len(decompressed) > 0 {
+		if text, ok := formatProtobuf(decompressed); ok {
+			return Result{
+				Format:      "s2+protobuf",
+				Text:        text,
+				RawSize:     len(raw),
+				DecodedSize: len(decompressed),
+			}, true
+		}
+	}
+
+	if text, ok := formatProtobuf(raw); ok {
+		return Result{
+			Format:      "protobuf",
+			Text:        text,
+			RawSize:     len(raw),
+			DecodedSize: len(raw),
+		}, true
+	}
+
+	return Result{}, false
+}
+
+// LooksLikeProtobuf reports whether raw is s2-compressed or raw protobuf.
+func LooksLikeProtobuf(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	if decompressed, err := s2.Decode(nil, raw); err == nil && len(decompressed) > 0 {
+		if isValidProtobuf(decompressed) {
+			return true
+		}
+	}
+	return isValidProtobuf(raw)
+}
+
+// isValidProtobuf walks the full wire payload; every field must parse cleanly.
+func isValidProtobuf(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	return consumeMessage(b) == len(b)
+}
+
+// consumeMessage returns bytes consumed if b is a valid message, else -1.
+func consumeMessage(b []byte) int {
+	i := 0
+	fields := 0
+	for i < len(b) {
+		tag, n := protowire.ConsumeVarint(b[i:])
+		if n < 0 {
+			return -1
+		}
+		i += n
+		num := protowire.Number(tag >> 3)
+		wt := protowire.Type(tag & 7)
+		if num < 1 {
+			return -1
+		}
+		switch wt {
+		case protowire.VarintType:
+			_, n = protowire.ConsumeVarint(b[i:])
+		case protowire.Fixed64Type:
+			_, n = protowire.ConsumeFixed64(b[i:])
+		case protowire.BytesType:
+			_, n = protowire.ConsumeBytes(b[i:])
+		case protowire.Fixed32Type:
+			_, n = protowire.ConsumeFixed32(b[i:])
+		default:
+			// Groups (3/4) and unknown wire types are rejected.
+			return -1
+		}
+		if n < 0 {
+			return -1
+		}
+		i += n
+		fields++
+	}
+	if fields == 0 {
+		return -1
+	}
+	return i
+}
+
+// formatProtobuf pretty-prints a wire message; ok is false if invalid.
+func formatProtobuf(b []byte) (string, bool) {
+	if !isValidProtobuf(b) {
+		return "", false
+	}
+	var sb strings.Builder
+	writeMessage(&sb, b, 0)
+	return sb.String(), true
+}
+
+// writeMessage appends a pretty-printed message (caller validated the wire).
+func writeMessage(sb *strings.Builder, b []byte, depth int) {
+	i := 0
+	fields := 0
+	for i < len(b) {
+		if sb.Len() >= maxDecodeText {
+			fmt.Fprintf(sb, "%s… truncated\n", indent(depth))
+			return
+		}
+		if fields >= maxFields {
+			fmt.Fprintf(sb, "%s… more fields\n", indent(depth))
+			return
+		}
+		tag, n := protowire.ConsumeVarint(b[i:])
+		i += n
+		num := protowire.Number(tag >> 3)
+		wt := protowire.Type(tag & 7)
+
+		switch wt {
+		case protowire.VarintType:
+			v, n := protowire.ConsumeVarint(b[i:])
+			i += n
+			fmt.Fprintf(sb, "%s%d: %d\n", indent(depth), num, v)
+		case protowire.Fixed64Type:
+			v, n := protowire.ConsumeFixed64(b[i:])
+			i += n
+			fmt.Fprintf(sb, "%s%d: 0x%x\n", indent(depth), num, v)
+		case protowire.BytesType:
+			v, n := protowire.ConsumeBytes(b[i:])
+			i += n
+			writeBytesField(sb, int(num), v, depth)
+		case protowire.Fixed32Type:
+			v, n := protowire.ConsumeFixed32(b[i:])
+			i += n
+			fmt.Fprintf(sb, "%s%d: 0x%x\n", indent(depth), num, v)
+		}
+		fields++
+	}
+}
+
+// writeBytesField renders a length-delimited field as string, nested message, or bytes.
+func writeBytesField(sb *strings.Builder, num int, v []byte, depth int) {
+	if isPrintableUTF8(v) {
+		fmt.Fprintf(sb, "%s%d: %q\n", indent(depth), num, string(v))
+		return
+	}
+	if depth < maxDepth && isValidProtobuf(v) {
+		fmt.Fprintf(sb, "%s%d: {\n", indent(depth), num)
+		writeMessage(sb, v, depth+1)
+		fmt.Fprintf(sb, "%s}\n", indent(depth))
+		return
+	}
+	fmt.Fprintf(sb, "%s%d: <%d bytes>\n", indent(depth), num, len(v))
+}
+
+// isPrintableUTF8 reports whether b is valid UTF-8 with no control chars (except tab/newline).
+func isPrintableUTF8(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	if !utf8.Valid(b) {
+		return false
+	}
+	for _, r := range string(b) {
+		if r == '\t' || r == '\n' || r == '\r' {
+			continue
+		}
+		if r < 32 || r == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+// indent returns depth*2 spaces.
+func indent(depth int) string {
+	if depth <= 0 {
+		return ""
+	}
+	return strings.Repeat("  ", depth)
+}

--- a/internal/decode/binary_test.go
+++ b/internal/decode/binary_test.go
@@ -150,6 +150,34 @@ func TestConsumeMessage_Errors(t *testing.T) {
 	}
 }
 
+func TestSplitTag(t *testing.T) {
+	num, wt, ok := splitTag(0x08) // field 1, varint
+	if !ok || num != 1 || wt != wireVarint {
+		t.Errorf("splitTag(0x08) = %d %d %v", num, wt, ok)
+	}
+	if _, _, ok := splitTag(0); ok {
+		t.Error("field 0 should fail")
+	}
+	// field number past max via high bits
+	if _, _, ok := splitTag((maxFieldNumber + 1) << 3); ok {
+		t.Error("oversized field should fail")
+	}
+}
+
+func TestWriteMessage_InvalidTagStops(t *testing.T) {
+	// After isValidProtobuf passed, writeMessage trusts tags; call it with
+	// a crafted buffer that has a valid first field then a field-0 tag so
+	// splitTag fails mid-message (defensive early return).
+	var b []byte
+	b = append(b, encodeVarintField(1, 1)...)
+	b = append(b, 0x00) // field 0 tag
+	var sb strings.Builder
+	writeMessage(&sb, b, 0)
+	if !strings.Contains(sb.String(), "1: 1") {
+		t.Errorf("expected first field rendered, got %q", sb.String())
+	}
+}
+
 func TestFormatProtobuf_FixedTypesAndOpaque(t *testing.T) {
 	var b []byte
 	b = protowire.AppendTag(b, 1, protowire.Fixed64Type)

--- a/internal/decode/binary_test.go
+++ b/internal/decode/binary_test.go
@@ -1,0 +1,270 @@
+package decode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/s2"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// encodeStringField builds a single length-delimited string field.
+func encodeStringField(num protowire.Number, s string) []byte {
+	var b []byte
+	b = protowire.AppendTag(b, num, protowire.BytesType)
+	b = protowire.AppendString(b, s)
+	return b
+}
+
+// encodeVarintField builds a single varint field.
+func encodeVarintField(num protowire.Number, v uint64) []byte {
+	var b []byte
+	b = protowire.AppendTag(b, num, protowire.VarintType)
+	b = protowire.AppendVarint(b, v)
+	return b
+}
+
+// encodeNested builds field num wrapping an inner message.
+func encodeNested(num protowire.Number, inner []byte) []byte {
+	var b []byte
+	b = protowire.AppendTag(b, num, protowire.BytesType)
+	b = protowire.AppendBytes(b, inner)
+	return b
+}
+
+func TestTryBinary_RawProtobuf(t *testing.T) {
+	raw := encodeStringField(1, "rst-demo:DELIVERY")
+	raw = append(raw, encodeStringField(3, "America/Toronto")...)
+	raw = append(raw, encodeVarintField(5, 42)...)
+
+	got, ok := TryBinary(raw)
+	if !ok {
+		t.Fatal("TryBinary returned false for valid protobuf")
+	}
+	if got.Format != "protobuf" {
+		t.Errorf("Format = %q, want protobuf", got.Format)
+	}
+	if got.RawSize != len(raw) {
+		t.Errorf("RawSize = %d, want %d", got.RawSize, len(raw))
+	}
+	if !containsAll(got.Text, []string{`1: "rst-demo:DELIVERY"`, `3: "America/Toronto"`, `5: 42`}) {
+		t.Errorf("Text missing expected fields:\n%s", got.Text)
+	}
+}
+
+func TestTryBinary_S2CompressedProtobuf(t *testing.T) {
+	raw := encodeStringField(1, "menu-id")
+	raw = append(raw, encodeNested(4, encodeStringField(1, "cat-1"))...)
+	compressed := s2.Encode(nil, raw)
+
+	got, ok := TryBinary(compressed)
+	if !ok {
+		t.Fatal("TryBinary returned false for s2+protobuf")
+	}
+	if got.Format != "s2+protobuf" {
+		t.Errorf("Format = %q, want s2+protobuf", got.Format)
+	}
+	if got.RawSize != len(compressed) {
+		t.Errorf("RawSize = %d, want %d", got.RawSize, len(compressed))
+	}
+	if got.DecodedSize != len(raw) {
+		t.Errorf("DecodedSize = %d, want %d", got.DecodedSize, len(raw))
+	}
+	if !containsAll(got.Text, []string{`1: "menu-id"`, `4: {`, `1: "cat-1"`}) {
+		t.Errorf("Text missing expected nested fields:\n%s", got.Text)
+	}
+}
+
+func TestTryBinary_RejectsRandomBinary(t *testing.T) {
+	raw := make([]byte, 32)
+	raw[0] = 0xC1
+	raw[10] = 0x01
+	if _, ok := TryBinary(raw); ok {
+		t.Fatal("TryBinary should reject non-protobuf binary")
+	}
+}
+
+func TestTryBinary_RejectsEmpty(t *testing.T) {
+	if _, ok := TryBinary(nil); ok {
+		t.Fatal("empty should fail")
+	}
+	if _, ok := TryBinary([]byte{}); ok {
+		t.Fatal("empty slice should fail")
+	}
+}
+
+func TestLooksLikeProtobuf(t *testing.T) {
+	if LooksLikeProtobuf(nil) || LooksLikeProtobuf([]byte{}) {
+		t.Error("empty should not look like protobuf")
+	}
+	raw := encodeStringField(1, "hello")
+	if !LooksLikeProtobuf(raw) {
+		t.Error("expected raw protobuf to look like protobuf")
+	}
+	if !LooksLikeProtobuf(s2.Encode(nil, raw)) {
+		t.Error("expected s2 protobuf to look like protobuf")
+	}
+	if LooksLikeProtobuf([]byte{0xff, 0xfe, 0x00}) {
+		t.Error("random binary should not look like protobuf")
+	}
+	// s2 of non-protobuf
+	if LooksLikeProtobuf(s2.Encode(nil, []byte{0xff, 0xfe, 0xfd, 0x00, 0x01})) {
+		t.Error("s2 of random bytes should not look like protobuf")
+	}
+}
+
+func TestIsValidProtobuf_Empty(t *testing.T) {
+	if isValidProtobuf(nil) || isValidProtobuf([]byte{}) {
+		t.Error("empty invalid")
+	}
+}
+
+func TestConsumeMessage_Errors(t *testing.T) {
+	if consumeMessage([]byte{}) >= 0 {
+		t.Error("empty should fail")
+	}
+	if consumeMessage([]byte{0x00}) >= 0 {
+		t.Error("field 0 should fail")
+	}
+	if consumeMessage([]byte{0x08}) >= 0 {
+		t.Error("truncated varint should fail")
+	}
+	if consumeMessage([]byte{0x09, 0x01}) >= 0 {
+		t.Error("truncated fixed64 should fail")
+	}
+	if consumeMessage([]byte{0x0d, 0x01}) >= 0 {
+		t.Error("truncated fixed32 should fail")
+	}
+	if consumeMessage([]byte{0x0a, 0x05, 0x01}) >= 0 {
+		t.Error("truncated bytes should fail")
+	}
+	if consumeMessage([]byte{0x0b}) >= 0 {
+		t.Error("start group should fail")
+	}
+	if consumeMessage([]byte{0x0f}) >= 0 {
+		t.Error("illegal wire type should fail")
+	}
+	// incomplete leading tag varint
+	if consumeMessage([]byte{0x80}) >= 0 {
+		t.Error("truncated tag should fail")
+	}
+}
+
+func TestFormatProtobuf_FixedTypesAndOpaque(t *testing.T) {
+	var b []byte
+	b = protowire.AppendTag(b, 1, protowire.Fixed64Type)
+	b = protowire.AppendFixed64(b, 0x1122334455667788)
+	b = protowire.AppendTag(b, 2, protowire.Fixed32Type)
+	b = protowire.AppendFixed32(b, 0xaabbccdd)
+	b = protowire.AppendTag(b, 3, protowire.BytesType)
+	b = protowire.AppendBytes(b, []byte{0x00, 0x01, 0xff})
+
+	text, ok := formatProtobuf(b)
+	if !ok {
+		t.Fatal("formatProtobuf failed")
+	}
+	if !strings.Contains(text, "1: 0x") || !strings.Contains(text, "2: 0x") || !strings.Contains(text, "3: <3 bytes>") {
+		t.Errorf("unexpected text:\n%s", text)
+	}
+}
+
+func TestFormatProtobuf_Invalid(t *testing.T) {
+	if _, ok := formatProtobuf([]byte{0xff}); ok {
+		t.Error("invalid should fail")
+	}
+}
+
+func TestWriteMessage_TruncationBySize(t *testing.T) {
+	var b []byte
+	payload := strings.Repeat("x", 200)
+	for i := 0; i < 400; i++ {
+		b = append(b, encodeStringField(1, payload)...)
+	}
+	text, ok := formatProtobuf(b)
+	if !ok {
+		t.Fatal("formatProtobuf failed on large message")
+	}
+	if !strings.Contains(text, "truncated") {
+		t.Errorf("expected truncation marker, got len=%d", len(text))
+	}
+}
+
+func TestWriteMessage_TruncationByFieldCount(t *testing.T) {
+	// Temporarily lower maxFields via many tiny fields — maxFields is 5000.
+	// Building 5001 varint fields is fine.
+	var b []byte
+	for i := 0; i < maxFields+10; i++ {
+		b = append(b, encodeVarintField(1, uint64(i%128))...)
+	}
+	text, ok := formatProtobuf(b)
+	if !ok {
+		t.Fatal("formatProtobuf failed")
+	}
+	if !strings.Contains(text, "more fields") {
+		t.Errorf("expected field-cap marker:\n%s", text[len(text)-80:])
+	}
+}
+
+func TestWriteBytesField_MaxDepth(t *testing.T) {
+	// Nest messages deeper than maxDepth → innermost becomes opaque bytes.
+	inner := encodeVarintField(1, 1)
+	for d := 0; d < maxDepth+2; d++ {
+		inner = encodeNested(1, inner)
+	}
+	text, ok := formatProtobuf(inner)
+	if !ok {
+		t.Fatal("formatProtobuf failed for deep nest")
+	}
+	if !strings.Contains(text, "bytes>") {
+		t.Errorf("expected depth-capped opaque bytes:\n%s", text)
+	}
+}
+
+func TestIsPrintableUTF8(t *testing.T) {
+	if !isPrintableUTF8([]byte("hello")) {
+		t.Error("ascii should be printable")
+	}
+	if !isPrintableUTF8([]byte("ok\t\n\r")) {
+		t.Error("tab/newline/return should be allowed")
+	}
+	if isPrintableUTF8([]byte{0x00, 0x01}) {
+		t.Error("control bytes should not be printable")
+	}
+	if isPrintableUTF8([]byte{}) {
+		t.Error("empty should not be printable")
+	}
+	if isPrintableUTF8([]byte{0x01}) {
+		t.Error("SOH control should fail")
+	}
+	if isPrintableUTF8([]byte{0x7f}) {
+		t.Error("DEL should fail")
+	}
+	if isPrintableUTF8([]byte{0xff, 0xfe}) {
+		t.Error("invalid utf8 should fail")
+	}
+}
+
+func TestIndent(t *testing.T) {
+	if indent(0) != "" {
+		t.Error("depth 0")
+	}
+	if indent(2) != "    " {
+		t.Errorf("depth 2 = %q", indent(2))
+	}
+}
+
+func TestTryBinary_EmptyAfterS2(t *testing.T) {
+	compressed := s2.Encode(nil, []byte{})
+	if _, ok := TryBinary(compressed); ok {
+		t.Error("empty decompressed should not succeed")
+	}
+}
+
+func containsAll(s string, parts []string) bool {
+	for _, p := range parts {
+		if !strings.Contains(s, p) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/redis/enumeration.go
+++ b/internal/redis/enumeration.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/davidbudnick/redis-tui/internal/decode"
 	"github.com/davidbudnick/redis-tui/internal/types"
 	"github.com/redis/go-redis/v9"
 )
@@ -414,9 +415,9 @@ func (c *Client) GetKeyPrefixes(separator string, maxDepth int) ([]string, error
 	return result, nil
 }
 
-// detectStringSubtypes checks string-typed keys for HLL/bitmap subtypes using
-// a single pipeline GET. Keys whose raw value starts with "HYLL" become
-// KeyTypeHyperLogLog; keys with binary (non-UTF-8) content become KeyTypeBitmap.
+// detectStringSubtypes checks string-typed keys for HLL/protobuf/bitmap subtypes
+// using a single pipeline GET. HYLL prefix → hyperloglog; s2/protobuf binary →
+// protobuf; remaining invalid UTF-8 → bitmap.
 func (c *Client) detectStringSubtypes(keys []types.RedisKey) []types.RedisKey {
 	// Collect indices of string keys
 	var stringIdxs []int
@@ -443,6 +444,8 @@ func (c *Client) detectStringSubtypes(keys []types.RedisKey) []types.RedisKey {
 		}
 		if len(val) >= 4 && val[:4] == "HYLL" {
 			keys[idx].Type = types.KeyTypeHyperLogLog
+		} else if decode.LooksLikeProtobuf([]byte(val)) {
+			keys[idx].Type = types.KeyTypeProtobuf
 		} else if isBinaryString(val) {
 			keys[idx].Type = types.KeyTypeBitmap
 		}

--- a/internal/redis/enumeration_test.go
+++ b/internal/redis/enumeration_test.go
@@ -824,6 +824,26 @@ func TestScanKeys_DetectStringSubtypes_Bitmap(t *testing.T) {
 	}
 }
 
+func TestScanKeys_DetectStringSubtypes_Protobuf(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	var raw []byte
+	raw = append(raw, 0x0a, 0x04)
+	raw = append(raw, []byte("menu")...)
+	mr.Set("proto:detect", string(raw))
+
+	keys, _, err := client.ScanKeys("proto:detect", 0, 100)
+	if err != nil {
+		t.Fatalf("ScanKeys error: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+	if keys[0].Type != types.KeyTypeProtobuf {
+		t.Errorf("type = %q, want protobuf", keys[0].Type)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // detectStringSubtypes — Get error path on a single string key. We use the
 // fake server to return one key from SCAN, "string" type, then have GET fail.

--- a/internal/redis/io.go
+++ b/internal/redis/io.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/davidbudnick/redis-tui/internal/decode"
 	"github.com/davidbudnick/redis-tui/internal/types"
 	"github.com/redis/go-redis/v9"
 )
@@ -315,6 +316,18 @@ func extractValue(keyType string, r valueFetchCmds) types.RedisValue {
 	case "string":
 		if r.strCmd != nil {
 			value.StringValue, _ = r.strCmd.Result()
+			if len(value.StringValue) >= 4 && value.StringValue[:4] == "HYLL" {
+				value.Type = types.KeyTypeHyperLogLog
+			} else if decoded, ok := decode.TryBinary([]byte(value.StringValue)); ok {
+				value.Type = types.KeyTypeProtobuf
+				value.DecodedValue = decoded.Text
+				value.DecodedFormat = decoded.Format
+				value.RawSize = decoded.RawSize
+				value.DecodedSize = decoded.DecodedSize
+			} else if isBinaryString(value.StringValue) {
+				value.Type = types.KeyTypeBitmap
+				value.BitPositions = extractBitPositions([]byte(value.StringValue), maxBitPositions)
+			}
 		}
 	case "list":
 		if r.listCmd != nil {

--- a/internal/redis/io_test.go
+++ b/internal/redis/io_test.go
@@ -1016,6 +1016,58 @@ func TestQueueValueFetch_ReJSON(t *testing.T) {
 	}
 }
 
+func TestCompareKeys_StringSubtypes(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	var protoRaw []byte
+	protoRaw = append(protoRaw, 0x0a, 0x03)
+	protoRaw = append(protoRaw, []byte("abc")...)
+	mr.Set("proto", string(protoRaw))
+	mr.Set("hll", "HYLL"+string(make([]byte, 12)))
+
+	v1, v2, err := client.CompareKeys("proto", "hll")
+	if err != nil {
+		t.Fatalf("CompareKeys error: %v", err)
+	}
+	if v1.Type != types.KeyTypeProtobuf {
+		t.Errorf("proto type = %q, want protobuf", v1.Type)
+	}
+	if v1.DecodedValue == "" || !containsStr(v1.DecodedValue, `1: "abc"`) {
+		t.Errorf("proto decoded = %q", v1.DecodedValue)
+	}
+	if v2.Type != types.KeyTypeHyperLogLog {
+		t.Errorf("hll type = %q, want hyperloglog", v2.Type)
+	}
+
+	// Bitmap path: invalid UTF-8 that is not protobuf.
+	if err := client.SetBit("bm", 0, 1); err != nil {
+		t.Fatalf("SetBit: %v", err)
+	}
+	if err := client.SetBit("bm", 1, 1); err != nil {
+		t.Fatalf("SetBit: %v", err)
+	}
+	vb, _, err := client.CompareKeys("bm", "proto")
+	if err != nil {
+		t.Fatalf("CompareKeys bitmap error: %v", err)
+	}
+	if vb.Type != types.KeyTypeBitmap {
+		t.Errorf("bitmap type = %q, want bitmap", vb.Type)
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || indexOfStr(s, sub) >= 0)
+}
+
+func indexOfStr(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
 func TestExtractValue_AllTypes(t *testing.T) {
 	// Empty fetch cmds — verifies the nil-check branches in each case arm.
 	for _, kt := range []string{"string", "list", "set", "zset", "hash", "stream", "ReJSON-RL"} {

--- a/internal/redis/operations.go
+++ b/internal/redis/operations.go
@@ -4,9 +4,13 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/davidbudnick/redis-tui/internal/decode"
 	"github.com/davidbudnick/redis-tui/internal/types"
 	"github.com/redis/go-redis/v9"
 )
+
+// maxBitPositions caps how many set-bit offsets we materialize for display.
+const maxBitPositions = 256
 
 // GetValue retrieves the value for a key
 func (c *Client) GetValue(key string) (types.RedisValue, error) {
@@ -33,22 +37,14 @@ func (c *Client) GetValue(key string) (types.RedisValue, error) {
 			if err == nil {
 				value.HLLCount = count
 			}
+		} else if decoded, ok := decode.TryBinary([]byte(val)); ok {
+			value.Type = types.KeyTypeProtobuf
+			value.DecodedValue = decoded.Text
+			value.DecodedFormat = decoded.Format
+			value.RawSize = decoded.RawSize
+			value.DecodedSize = decoded.DecodedSize
 		} else if isBinaryString(val) {
-			// Detect Bitmap: binary data (not HLL)
-			value.Type = types.KeyTypeBitmap
-			count, err := c.cmdable().BitCount(c.ctx, key, &redis.BitCount{Start: 0, End: -1}).Result()
-			if err == nil {
-				value.BitCount = count
-			}
-			// Extract set bit positions from raw bytes
-			for byteIdx := 0; byteIdx < len(val); byteIdx++ {
-				b := val[byteIdx]
-				for bit := 7; bit >= 0; bit-- {
-					if b&(1<<uint(bit)) != 0 {
-						value.BitPositions = append(value.BitPositions, int64(byteIdx*8+(7-bit)))
-					}
-				}
-			}
+			applyBinaryStringValue(&value, val, c, key)
 		}
 
 	case "list":
@@ -155,6 +151,36 @@ func isBinaryString(s string) bool {
 		return false
 	}
 	return !utf8.ValidString(s)
+}
+
+// applyBinaryStringValue classifies remaining binary Redis strings as bitmaps.
+func applyBinaryStringValue(value *types.RedisValue, val string, c *Client, key string) {
+	value.Type = types.KeyTypeBitmap
+	count, err := c.cmdable().BitCount(c.ctx, key, &redis.BitCount{Start: 0, End: -1}).Result()
+	if err == nil {
+		value.BitCount = count
+	}
+	value.BitPositions = extractBitPositions([]byte(val), maxBitPositions)
+}
+
+// extractBitPositions returns up to max set bit offsets from raw bytes.
+func extractBitPositions(val []byte, max int) []int64 {
+	if max <= 0 {
+		return nil
+	}
+	var positions []int64
+	for byteIdx := 0; byteIdx < len(val); byteIdx++ {
+		b := val[byteIdx]
+		for bit := 7; bit >= 0; bit-- {
+			if b&(1<<uint(bit)) != 0 {
+				positions = append(positions, int64(byteIdx*8+(7-bit)))
+				if len(positions) >= max {
+					return positions
+				}
+			}
+		}
+	}
+	return positions
 }
 
 // JSONGet retrieves a JSON value from a RedisJSON key

--- a/internal/redis/operations_test.go
+++ b/internal/redis/operations_test.go
@@ -1,13 +1,16 @@
 package redis
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/davidbudnick/redis-tui/internal/types"
+	"github.com/klauspost/compress/s2"
 	goredis "github.com/redis/go-redis/v9"
 )
 
@@ -599,6 +602,86 @@ func TestGetValue_Bitmap(t *testing.T) {
 	}
 	if len(v.BitPositions) != 3 {
 		t.Errorf("BitPositions length = %d, want 3", len(v.BitPositions))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetValue — Protobuf (raw + s2-compressed) branch
+// ---------------------------------------------------------------------------
+
+func TestGetValue_Protobuf(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	// field 1 string "menu-id", field 5 varint 7
+	var raw []byte
+	raw = append(raw, 0x0a, 0x07) // tag 1, len 7
+	raw = append(raw, []byte("menu-id")...)
+	raw = append(raw, 0x28, 0x07) // tag 5, varint 7
+
+	mr.Set("proto:raw", string(raw))
+	v, err := client.GetValue("proto:raw")
+	if err != nil {
+		t.Fatalf("GetValue error: %v", err)
+	}
+	if v.Type != types.KeyTypeProtobuf {
+		t.Fatalf("Type = %q, want %q", v.Type, types.KeyTypeProtobuf)
+	}
+	if v.DecodedFormat != "protobuf" {
+		t.Errorf("DecodedFormat = %q, want protobuf", v.DecodedFormat)
+	}
+	if !strings.Contains(v.DecodedValue, `1: "menu-id"`) {
+		t.Errorf("DecodedValue missing menu-id field:\n%s", v.DecodedValue)
+	}
+	if !strings.Contains(v.DecodedValue, "5: 7") {
+		t.Errorf("DecodedValue missing field 5:\n%s", v.DecodedValue)
+	}
+}
+
+func TestGetValue_Protobuf_S2(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	var raw []byte
+	raw = append(raw, 0x0a, 0x04)
+	raw = append(raw, []byte("abcd")...)
+	compressed := s2.Encode(nil, raw)
+
+	mr.Set("proto:s2", string(compressed))
+	v, err := client.GetValue("proto:s2")
+	if err != nil {
+		t.Fatalf("GetValue error: %v", err)
+	}
+	if v.Type != types.KeyTypeProtobuf {
+		t.Fatalf("Type = %q, want %q", v.Type, types.KeyTypeProtobuf)
+	}
+	if v.DecodedFormat != "s2+protobuf" {
+		t.Errorf("DecodedFormat = %q, want s2+protobuf", v.DecodedFormat)
+	}
+	if v.RawSize != len(compressed) {
+		t.Errorf("RawSize = %d, want %d", v.RawSize, len(compressed))
+	}
+	if v.DecodedSize != len(raw) {
+		t.Errorf("DecodedSize = %d, want %d", v.DecodedSize, len(raw))
+	}
+	if !strings.Contains(v.DecodedValue, `1: "abcd"`) {
+		t.Errorf("DecodedValue missing field:\n%s", v.DecodedValue)
+	}
+}
+
+func TestExtractBitPositions_Caps(t *testing.T) {
+	// 32 bytes all 0xff → 256 set bits; cap at 10.
+	raw := bytes.Repeat([]byte{0xff}, 32)
+	got := extractBitPositions(raw, 10)
+	if len(got) != 10 {
+		t.Fatalf("len = %d, want 10", len(got))
+	}
+	if got[0] != 0 || got[9] != 9 {
+		t.Errorf("positions = %v, want 0..9", got)
+	}
+	if extractBitPositions(raw, 0) != nil {
+		t.Error("max 0 should return nil")
+	}
+	if extractBitPositions(raw, -1) != nil {
+		t.Error("negative max should return nil")
 	}
 }
 

--- a/internal/types/redis.go
+++ b/internal/types/redis.go
@@ -6,16 +6,17 @@ import "time"
 type KeyType string
 
 const (
-	KeyTypeString KeyType = "string"
-	KeyTypeList   KeyType = "list"
-	KeyTypeSet    KeyType = "set"
-	KeyTypeZSet   KeyType = "zset"
-	KeyTypeHash   KeyType = "hash"
-	KeyTypeStream KeyType = "stream"
+	KeyTypeString      KeyType = "string"
+	KeyTypeList        KeyType = "list"
+	KeyTypeSet         KeyType = "set"
+	KeyTypeZSet        KeyType = "zset"
+	KeyTypeHash        KeyType = "hash"
+	KeyTypeStream      KeyType = "stream"
 	KeyTypeJSON        KeyType = "ReJSON-RL"
 	KeyTypeHyperLogLog KeyType = "hyperloglog"
 	KeyTypeBitmap      KeyType = "bitmap"
 	KeyTypeGeo         KeyType = "geo"
+	KeyTypeProtobuf    KeyType = "protobuf"
 )
 
 // RedisKey represents a key with metadata
@@ -29,18 +30,25 @@ type RedisKey struct {
 
 // RedisValue holds the value for any Redis type
 type RedisValue struct {
-	Type        KeyType
-	StringValue string
-	ListValue   []string
-	SetValue    []string
-	ZSetValue   []ZSetMember
-	HashValue   map[string]string
-	StreamValue []StreamEntry
-	JSONValue   string
+	Type         KeyType
+	StringValue  string
+	ListValue    []string
+	SetValue     []string
+	ZSetValue    []ZSetMember
+	HashValue    map[string]string
+	StreamValue  []StreamEntry
+	JSONValue    string
 	HLLCount     int64       // cardinality for HyperLogLog (from PFCOUNT)
 	GeoValue     []GeoMember // members with coordinates for Geo
 	BitCount     int64       // bit count for Bitmap (from BITCOUNT)
 	BitPositions []int64     // set bit positions for Bitmap display
+	// DecodedValue is a human-readable rendering for binary formats (e.g. protobuf).
+	DecodedValue string
+	// DecodedFormat labels how DecodedValue was produced (e.g. "s2+protobuf").
+	DecodedFormat string
+	// RawSize / DecodedSize track original vs decompressed payload sizes.
+	RawSize     int
+	DecodedSize int
 }
 
 // GeoMember represents a geospatial member with coordinates

--- a/internal/ui/gaps_test.go
+++ b/internal/ui/gaps_test.go
@@ -325,10 +325,10 @@ func TestHandleKeyDetailScreen_ScrollClamp(t *testing.T) {
 func TestHandleKeyDetailScreen_PgUpClamp(t *testing.T) {
 	m, _, _ := newTestModel(t)
 	m.CurrentKey = &types.RedisKey{Key: "foo", Type: types.KeyTypeString}
-	m.DetailScroll = 3 // pgup -10 → -7 → clamp to 0
+	m.DetailCursor = 3 // pgup -10 → -7 → clamp to 0
 	result, _ := m.handleKeyDetailScreen(tea.KeyPressMsg{Code: tea.KeyPgUp})
-	if result.(Model).DetailScroll != 0 {
-		t.Errorf("expected 0, got %d", result.(Model).DetailScroll)
+	if result.(Model).DetailCursor != 0 {
+		t.Errorf("expected 0, got %d", result.(Model).DetailCursor)
 	}
 }
 

--- a/internal/ui/messages_keys.go
+++ b/internal/ui/messages_keys.go
@@ -41,6 +41,7 @@ func (m Model) handleKeyValueLoadedMsg(msg types.KeyValueLoadedMsg) (tea.Model, 
 	} else {
 		m.CurrentValue = msg.Value
 		m.DetailScroll = 0
+		m.DetailCursor = 0
 		// On-demand type resolution: fill in type if it was not fetched during scan,
 		// or update when GetValue detected a subtype (e.g. string→hyperloglog)
 		if m.CurrentKey != nil && msg.Value.Type != "" && m.CurrentKey.Type != msg.Value.Type {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -148,7 +148,8 @@ type Model struct {
 	PreviewKey    string
 	PreviewValue  types.RedisValue
 	PreviewScroll int
-	DetailScroll  int
+	DetailScroll  int // viewport top line in the detail value body
+	DetailCursor  int // selected line in the detail value body (blue band)
 
 	// Live metrics dashboard
 	LiveMetrics       *types.LiveMetrics

--- a/internal/ui/screens_keys.go
+++ b/internal/ui/screens_keys.go
@@ -306,6 +306,7 @@ func (m Model) handleKeyDetailScreen(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.CurrentKey != nil {
 			m.Loading = true
 			m.DetailScroll = 0
+			m.DetailCursor = 0
 			return m, tea.Batch(m.Cmds.LoadKeyValue(m.CurrentKey.Key), m.Cmds.GetMemoryUsage(m.CurrentKey.Key))
 		}
 	case "e":
@@ -329,13 +330,15 @@ func (m Model) handleKeyDetailScreen(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.Screen = types.ScreenEditValue
 		}
 	case "a":
-		if m.CurrentKey != nil && m.CurrentKey.Type != types.KeyTypeString && m.CurrentKey.Type != types.KeyTypeJSON {
+		if m.CurrentKey != nil && m.CurrentKey.Type != types.KeyTypeString && m.CurrentKey.Type != types.KeyTypeJSON &&
+			m.CurrentKey.Type != types.KeyTypeProtobuf {
 			m.resetAddCollectionInputs()
 			m.Screen = types.ScreenAddToCollection
 		}
 	case "x":
 		if m.CurrentKey != nil && m.CurrentKey.Type != types.KeyTypeString && m.CurrentKey.Type != types.KeyTypeJSON &&
-			m.CurrentKey.Type != types.KeyTypeHyperLogLog && m.CurrentKey.Type != types.KeyTypeBitmap {
+			m.CurrentKey.Type != types.KeyTypeHyperLogLog && m.CurrentKey.Type != types.KeyTypeBitmap &&
+			m.CurrentKey.Type != types.KeyTypeProtobuf {
 			m.SelectedItemIdx = 0
 			m.Screen = types.ScreenRemoveFromCollection
 		}
@@ -382,7 +385,11 @@ func (m Model) handleKeyDetailScreen(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	case "y":
 		if m.CurrentKey != nil {
-			return m, m.Cmds.CopyToClipboard(m.CurrentValue.StringValue)
+			clip := m.CurrentValue.StringValue
+			if m.CurrentKey.Type == types.KeyTypeProtobuf && m.CurrentValue.DecodedValue != "" {
+				clip = m.CurrentValue.DecodedValue
+			}
+			return m, m.Cmds.CopyToClipboard(clip)
 		}
 	case "J":
 		if m.CurrentKey != nil && m.CurrentKey.Type == types.KeyTypeString {
@@ -391,38 +398,54 @@ func (m Model) handleKeyDetailScreen(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.Screen = types.ScreenJSONPath
 		}
 	case "up", "k":
-		if m.DetailScroll > 0 {
-			m.DetailScroll--
+		if m.DetailCursor > 0 {
+			m.DetailCursor--
+			m.syncDetailScroll()
 		} else if m.SelectedItemIdx > 0 {
 			m.SelectedItemIdx--
 		}
 	case "down", "j":
-		m.DetailScroll++
-		if m.DetailScroll > m.detailMaxScroll() {
-			m.DetailScroll = m.detailMaxScroll()
+		if m.DetailCursor+1 < m.detailContentLines() {
+			m.DetailCursor++
+			m.syncDetailScroll()
 		}
 	case "pgup", "ctrl+u":
-		m.DetailScroll -= 10
-		if m.DetailScroll < 0 {
-			m.DetailScroll = 0
+		m.DetailCursor -= 10
+		if m.DetailCursor < 0 {
+			m.DetailCursor = 0
 		}
+		m.syncDetailScroll()
 	case "pgdown", "ctrl+d":
-		m.DetailScroll += 10
-		if m.DetailScroll > m.detailMaxScroll() {
-			m.DetailScroll = m.detailMaxScroll()
+		m.DetailCursor += 10
+		if last := m.detailLastLine(); m.DetailCursor > last {
+			m.DetailCursor = last
 		}
+		m.syncDetailScroll()
 	case "home", "g":
-		m.DetailScroll = 0
+		m.DetailCursor = 0
+		m.syncDetailScroll()
 	case "end", "G":
-		m.DetailScroll = m.detailMaxScroll()
+		m.DetailCursor = m.detailLastLine()
+		m.syncDetailScroll()
 	case "esc", "backspace":
 		m.Screen = types.ScreenKeys
 		m.CurrentKey = nil
 		m.SelectedItemIdx = 0
 		m.DetailScroll = 0
+		m.DetailCursor = 0
 		m.WatchActive = false
 	}
 	return m, nil
+}
+
+// syncDetailScroll keeps DetailScroll aligned so DetailCursor stays visible.
+func (m *Model) syncDetailScroll() {
+	m.DetailCursor, m.DetailScroll = ensureDetailCursorVisible(
+		m.DetailCursor,
+		m.DetailScroll,
+		m.detailContentLines(),
+		detailMaxVisible(m.Height),
+	)
 }
 
 func (m Model) getCollectionLength() int {
@@ -439,7 +462,7 @@ func (m Model) getCollectionLength() int {
 		return len(m.CurrentValue.StreamValue)
 	case types.KeyTypeGeo:
 		return len(m.CurrentValue.GeoValue)
-	case types.KeyTypeHyperLogLog, types.KeyTypeJSON, types.KeyTypeBitmap:
+	case types.KeyTypeHyperLogLog, types.KeyTypeJSON, types.KeyTypeBitmap, types.KeyTypeProtobuf:
 		return 0
 	default:
 		return 0

--- a/internal/ui/screens_keys_test.go
+++ b/internal/ui/screens_keys_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -769,6 +770,34 @@ func TestHandleKeyDetailScreen(t *testing.T) {
 			t.Error("expected cmd")
 		}
 	})
+	t.Run("y copy protobuf decoded", func(t *testing.T) {
+		m, _ := newModelWithKey(t, types.KeyTypeProtobuf)
+		m.CurrentValue = types.RedisValue{
+			Type:         types.KeyTypeProtobuf,
+			StringValue:  "raw-binary",
+			DecodedValue: "1: \"decoded\"\n",
+		}
+		_, cmd := m.handleKeyDetailScreen(keyMsg('y'))
+		if cmd == nil {
+			t.Error("expected cmd")
+		}
+	})
+	t.Run("a ignored for protobuf", func(t *testing.T) {
+		m, _ := newModelWithKey(t, types.KeyTypeProtobuf)
+		result, _ := m.handleKeyDetailScreen(keyMsg('a'))
+		model := result.(Model)
+		if model.Screen == types.ScreenAddToCollection {
+			t.Error("protobuf should not open add-to-collection")
+		}
+	})
+	t.Run("x ignored for protobuf", func(t *testing.T) {
+		m, _ := newModelWithKey(t, types.KeyTypeProtobuf)
+		result, _ := m.handleKeyDetailScreen(keyMsg('x'))
+		model := result.(Model)
+		if model.Screen == types.ScreenRemoveFromCollection {
+			t.Error("protobuf should not open remove-from-collection")
+		}
+	})
 	t.Run("J json path", func(t *testing.T) {
 		m, _ := newModelWithKey(t, types.KeyTypeString)
 		result, _ := m.handleKeyDetailScreen(keyMsg('J'))
@@ -781,44 +810,86 @@ func TestHandleKeyDetailScreen(t *testing.T) {
 		m, _ := newModelWithKey(t, types.KeyTypeList)
 		_, _ = m.handleKeyDetailScreen(keyMsg('J'))
 	})
-	t.Run("up scroll detail", func(t *testing.T) {
+	t.Run("up cursor detail", func(t *testing.T) {
 		m, _ := newModelWithKey(t, types.KeyTypeString)
-		m.DetailScroll = 3
+		m.Height = 40
+		m.Width = 120
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: strings.Repeat("line\n", 20)}
+		m.DetailCursor = 3
 		result, _ := m.handleKeyDetailScreen(tea.KeyPressMsg{Code: tea.KeyUp})
 		model := result.(Model)
-		if model.DetailScroll != 2 {
-			t.Errorf("expected 2, got %d", model.DetailScroll)
+		if model.DetailCursor != 2 {
+			t.Errorf("expected cursor 2, got %d", model.DetailCursor)
 		}
 	})
 	t.Run("up scroll item", func(t *testing.T) {
 		m, _ := newModelWithKey(t, types.KeyTypeList)
 		m.SelectedItemIdx = 1
+		m.DetailCursor = 0
 		result, _ := m.handleKeyDetailScreen(keyMsg('k'))
 		model := result.(Model)
 		if model.SelectedItemIdx != 0 {
 			t.Errorf("expected 0, got %d", model.SelectedItemIdx)
 		}
 	})
-	t.Run("down scroll", func(t *testing.T) {
+	t.Run("down cursor", func(t *testing.T) {
 		m, _ := newModelWithKey(t, types.KeyTypeString)
-		_, _ = m.handleKeyDetailScreen(keyMsg('j'))
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: "a\nb\nc\nd\ne"}
+		m.DetailCursor = 0
+		result, _ := m.handleKeyDetailScreen(keyMsg('j'))
+		if result.(Model).DetailCursor != 1 {
+			t.Errorf("expected cursor 1, got %d", result.(Model).DetailCursor)
+		}
+	})
+	t.Run("down cursor clamps at end", func(t *testing.T) {
+		m, _ := newModelWithKey(t, types.KeyTypeString)
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: "only"}
+		m.DetailCursor = 0
+		result, _ := m.handleKeyDetailScreen(keyMsg('j'))
+		if result.(Model).DetailCursor != 0 {
+			t.Errorf("expected cursor stay 0, got %d", result.(Model).DetailCursor)
+		}
+	})
+	t.Run("pgdown clamps at end", func(t *testing.T) {
+		m, _ := newModelWithKey(t, types.KeyTypeString)
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: "a\nb"}
+		m.DetailCursor = 0
+		result, _ := m.handleKeyDetailScreen(tea.KeyPressMsg{Code: tea.KeyPgDown})
+		if result.(Model).DetailCursor != 1 {
+			t.Errorf("expected cursor 1, got %d", result.(Model).DetailCursor)
+		}
+	})
+	t.Run("end empty content", func(t *testing.T) {
+		m, _ := newModelWithKey(t, types.KeyTypeString)
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: ""}
+		result, _ := m.handleKeyDetailScreen(tea.KeyPressMsg{Code: tea.KeyEnd})
+		if result.(Model).DetailCursor != 0 {
+			t.Errorf("expected 0, got %d", result.(Model).DetailCursor)
+		}
 	})
 	t.Run("pgup detail", func(t *testing.T) {
 		m, _ := newModelWithKey(t, types.KeyTypeString)
-		m.DetailScroll = 20
-		_, _ = m.handleKeyDetailScreen(tea.KeyPressMsg{Code: tea.KeyPgUp})
+		m.Height = 40
+		m.Width = 120
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: strings.Repeat("line\n", 40)}
+		m.DetailCursor = 20
+		result, _ := m.handleKeyDetailScreen(tea.KeyPressMsg{Code: tea.KeyPgUp})
+		if result.(Model).DetailCursor != 10 {
+			t.Errorf("expected cursor 10, got %d", result.(Model).DetailCursor)
+		}
 	})
 	t.Run("pgdown detail", func(t *testing.T) {
 		m, _ := newModelWithKey(t, types.KeyTypeString)
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: strings.Repeat("line\n", 50)}
 		_, _ = m.handleKeyDetailScreen(tea.KeyPressMsg{Code: tea.KeyPgDown})
 	})
 	t.Run("home detail", func(t *testing.T) {
 		m, _ := newModelWithKey(t, types.KeyTypeString)
-		m.DetailScroll = 5
+		m.DetailCursor = 5
 		result, _ := m.handleKeyDetailScreen(tea.KeyPressMsg{Code: tea.KeyHome})
 		model := result.(Model)
-		if model.DetailScroll != 0 {
-			t.Errorf("expected 0, got %d", model.DetailScroll)
+		if model.DetailCursor != 0 {
+			t.Errorf("expected cursor 0, got %d", model.DetailCursor)
 		}
 	})
 	t.Run("g home", func(t *testing.T) {

--- a/internal/ui/view_keys_detail.go
+++ b/internal/ui/view_keys_detail.go
@@ -90,7 +90,7 @@ func (m Model) viewKeyDetail() string {
 	for i, line := range visible {
 		abs := displayScroll + i
 		if abs == m.DetailCursor {
-			// Phoenix-style full-width blue selection band (plain text, high contrast).
+			// Full-width blue selection band (plain text, high contrast).
 			plain := padRight(truncateRunes(line, contentWidth), contentWidth)
 			display.WriteString(selectedStyle.Render(plain))
 		} else if m.CurrentValue.Type == types.KeyTypeProtobuf {

--- a/internal/ui/view_keys_detail.go
+++ b/internal/ui/view_keys_detail.go
@@ -17,10 +17,8 @@ func (m Model) viewKeyDetail() string {
 		return "No key selected"
 	}
 
-	// Use ~60% of screen width for the detail view, capped reasonably
-	boxWidth := m.Width * 3 / 5
-	boxWidth = max(boxWidth, 50)
-	boxWidth = min(boxWidth, m.Width-6)
+	boxWidth := detailBoxWidth(m.Width)
+	contentWidth := detailContentWidth(boxWidth)
 
 	b.WriteString(lipgloss.PlaceHorizontal(boxWidth, lipgloss.Center, titleStyle.Render("Key Detail")))
 	b.WriteString("\n\n")
@@ -74,6 +72,78 @@ func (m Model) viewKeyDetail() string {
 		Padding(1, 2).
 		Width(boxWidth)
 
+	valueStr := m.detailValuePlainString()
+	// Wrap to the box content width so scroll line counts match what is painted.
+	valueLines := wrapPlainLines(strings.Split(valueStr, "\n"), contentWidth)
+	maxVisible := detailMaxVisible(m.Height)
+
+	// Derive a display scroll that keeps the cursor visible without mutating model state
+	// (View receives Model by value).
+	_, displayScroll := ensureDetailCursorVisible(m.DetailCursor, m.DetailScroll, len(valueLines), maxVisible)
+	visible, topHint, bottomHint, displayScroll := scrollValueLines(valueLines, displayScroll, maxVisible)
+
+	var display strings.Builder
+	if topHint != "" {
+		display.WriteString(topHint)
+		display.WriteByte('\n')
+	}
+	for i, line := range visible {
+		abs := displayScroll + i
+		if abs == m.DetailCursor {
+			// Phoenix-style full-width blue selection band (plain text, high contrast).
+			plain := padRight(truncateRunes(line, contentWidth), contentWidth)
+			display.WriteString(selectedStyle.Render(plain))
+		} else if m.CurrentValue.Type == types.KeyTypeProtobuf {
+			display.WriteString(colorizeProtobufLine(line))
+		} else {
+			display.WriteString(line)
+		}
+		if i < len(visible)-1 {
+			display.WriteByte('\n')
+		}
+	}
+	if bottomHint != "" {
+		display.WriteByte('\n')
+		display.WriteString(bottomHint)
+	}
+
+	b.WriteString(valueBox.Render(display.String()))
+	b.WriteString("\n\n")
+
+	helpText := "j/k:move  t:TTL  d:del  r:refresh  R:rename  c:copy"
+	switch m.CurrentKey.Type {
+	case types.KeyTypeString, types.KeyTypeJSON:
+		helpText += "  e:edit"
+	case types.KeyTypeHyperLogLog, types.KeyTypeBitmap:
+		helpText += "  a:add"
+	case types.KeyTypeProtobuf:
+		// read-only decoded view
+	default:
+		helpText += "  a:add  x:remove"
+	}
+	helpText += "  esc:back"
+	b.WriteString(lipgloss.PlaceHorizontal(boxWidth, lipgloss.Center, helpStyle.Render(helpText)))
+
+	return b.String()
+}
+
+func (m Model) detailContentLines() int {
+	lines := wrapPlainLines(strings.Split(m.detailValuePlainString(), "\n"), detailContentWidth(detailBoxWidth(m.Width)))
+	return len(lines)
+}
+
+// detailLastLine is the last selectable line index in the detail value body.
+func (m Model) detailLastLine() int {
+	return max(m.detailContentLines()-1, 0)
+}
+
+// detailValueString returns the detail body used by tests and line counting.
+func (m Model) detailValueString() string {
+	return m.detailValuePlainString()
+}
+
+// detailValuePlainString builds the unstyled value body for the detail pane.
+func (m Model) detailValuePlainString() string {
 	var vc strings.Builder
 	switch m.CurrentValue.Type {
 	case types.KeyTypeString:
@@ -108,7 +178,6 @@ func (m Model) viewKeyDetail() string {
 		if len(m.CurrentValue.HashValue) == 0 {
 			vc.WriteString("(empty hash)")
 		} else {
-			// Sort hash keys for consistent display
 			hashKeys := make([]string, 0, len(m.CurrentValue.HashValue))
 			for k := range m.CurrentValue.HashValue {
 				hashKeys = append(hashKeys, k)
@@ -117,7 +186,6 @@ func (m Model) viewKeyDetail() string {
 			for _, k := range hashKeys {
 				v := m.CurrentValue.HashValue[k]
 				formattedValue := formatPossibleJSON(v)
-				// Check if value is multi-line JSON
 				if strings.Contains(formattedValue, "\n") {
 					fmt.Fprintf(&vc, "◆ %s:\n%s\n", k, formattedValue)
 				} else {
@@ -130,7 +198,6 @@ func (m Model) viewKeyDetail() string {
 			vc.WriteString("(empty stream)")
 		} else {
 			for _, entry := range m.CurrentValue.StreamValue {
-				// Try to format stream fields as JSON
 				jsonBytes, err := json.MarshalIndent(entry.Fields, "", "  ")
 				if err == nil {
 					fmt.Fprintf(&vc, "%s:\n%s\n", entry.ID, string(jsonBytes))
@@ -147,12 +214,17 @@ func (m Model) viewKeyDetail() string {
 		vc.WriteString(formatPossibleJSON(m.CurrentValue.JSONValue))
 	case types.KeyTypeHyperLogLog:
 		fmt.Fprintf(&vc, "Estimated cardinality: %d", m.CurrentValue.HLLCount)
+	case types.KeyTypeProtobuf:
+		vc.WriteString(formatProtobufValue(m.CurrentValue))
 	case types.KeyTypeBitmap:
 		fmt.Fprintf(&vc, "Bit count: %d\n\n", m.CurrentValue.BitCount)
 		if len(m.CurrentValue.BitPositions) > 0 {
 			vc.WriteString("Set positions:\n")
 			for _, pos := range m.CurrentValue.BitPositions {
 				fmt.Fprintf(&vc, "  bit %d = 1\n", pos)
+			}
+			if m.CurrentValue.BitCount > int64(len(m.CurrentValue.BitPositions)) {
+				fmt.Fprintf(&vc, "  … and %d more\n", m.CurrentValue.BitCount-int64(len(m.CurrentValue.BitPositions)))
 			}
 		} else {
 			vc.WriteString("(all bits are 0)")
@@ -166,115 +238,42 @@ func (m Model) viewKeyDetail() string {
 			}
 		}
 	}
-
-	// Apply scrolling for long values
-	valueStr := strings.TrimSpace(vc.String())
-	valueLines := strings.Split(valueStr, "\n")
-	// Reserve lines for header (6) + border/padding (4) + help (2)
-	maxVisible := m.Height - 12
-	if maxVisible < 5 {
-		maxVisible = 5
-	}
-
-	if len(valueLines) > maxVisible {
-		if m.DetailScroll > len(valueLines)-maxVisible {
-			m.DetailScroll = len(valueLines) - maxVisible
-		}
-		if m.DetailScroll < 0 {
-			m.DetailScroll = 0
-		}
-		end := m.DetailScroll + maxVisible
-		visible := valueLines[m.DetailScroll:end]
-		var scrollInfo string
-		if m.DetailScroll > 0 {
-			scrollInfo += dimStyle.Render(fmt.Sprintf("↑ %d more lines above", m.DetailScroll))
-			scrollInfo += "\n"
-		}
-		scrollInfo += strings.Join(visible, "\n")
-		remaining := len(valueLines) - end
-		if remaining > 0 {
-			scrollInfo += "\n"
-			scrollInfo += dimStyle.Render(fmt.Sprintf("↓ %d more lines below", remaining))
-		}
-		valueStr = scrollInfo
-	}
-
-	b.WriteString(valueBox.Render(valueStr))
-	b.WriteString("\n\n")
-
-	helpText := "t:TTL  d:del  r:refresh  R:rename  c:copy"
-	switch m.CurrentKey.Type {
-	case types.KeyTypeString, types.KeyTypeJSON:
-		helpText += "  e:edit"
-	case types.KeyTypeHyperLogLog, types.KeyTypeBitmap:
-		helpText += "  a:add"
-	default:
-		helpText += "  a:add  x:remove"
-	}
-	helpText += "  esc:back"
-	b.WriteString(lipgloss.PlaceHorizontal(boxWidth, lipgloss.Center, helpStyle.Render(helpText)))
-
-
-	return b.String()
-}
-
-func (m Model) detailContentLines() int {
-	return strings.Count(m.detailValueString(), "\n") + 1
-}
-
-func (m Model) detailValueString() string {
-	var vc strings.Builder
-	switch m.CurrentValue.Type {
-	case types.KeyTypeString:
-		vc.WriteString(formatPossibleJSON(m.CurrentValue.StringValue))
-	case types.KeyTypeList:
-		for i, v := range m.CurrentValue.ListValue {
-			fmt.Fprintf(&vc, "%d. %s\n", i, v)
-		}
-	case types.KeyTypeSet:
-		for _, v := range m.CurrentValue.SetValue {
-			fmt.Fprintf(&vc, "• %s\n", v)
-		}
-	case types.KeyTypeZSet:
-		for _, v := range m.CurrentValue.ZSetValue {
-			fmt.Fprintf(&vc, "%.2f: %s\n", v.Score, v.Member)
-		}
-	case types.KeyTypeHash:
-		for k, v := range m.CurrentValue.HashValue {
-			fmt.Fprintf(&vc, "%s: %s\n", k, v)
-		}
-	case types.KeyTypeStream:
-		for _, e := range m.CurrentValue.StreamValue {
-			fmt.Fprintf(&vc, "%s\n", e.ID)
-		}
-	case types.KeyTypeJSON:
-		vc.WriteString(formatPossibleJSON(m.CurrentValue.JSONValue))
-	case types.KeyTypeHyperLogLog:
-		fmt.Fprintf(&vc, "Estimated cardinality: %d", m.CurrentValue.HLLCount)
-	case types.KeyTypeBitmap:
-		fmt.Fprintf(&vc, "Bit count: %d\n", m.CurrentValue.BitCount)
-		for _, pos := range m.CurrentValue.BitPositions {
-			fmt.Fprintf(&vc, "  bit %d = 1\n", pos)
-		}
-	case types.KeyTypeGeo:
-		for _, g := range m.CurrentValue.GeoValue {
-			fmt.Fprintf(&vc, "%s  (%.6f, %.6f)\n", g.Name, g.Longitude, g.Latitude)
-		}
-	}
 	return strings.TrimSpace(vc.String())
 }
 
-func (m Model) detailMaxScroll() int {
-	maxVisible := m.Height - 12
-	if maxVisible < 5 {
-		maxVisible = 5
+// formatProtobufValue renders decoded protobuf metadata and text body.
+func formatProtobufValue(v types.RedisValue) string {
+	var b strings.Builder
+	format := v.DecodedFormat
+	if format == "" {
+		format = "protobuf"
 	}
+	fmt.Fprintf(&b, "Format: %s\n", format)
+	if v.RawSize > 0 {
+		if v.DecodedSize > 0 && v.DecodedSize != v.RawSize {
+			fmt.Fprintf(&b, "Size: %s compressed → %s decoded\n", formatBytes(int64(v.RawSize)), formatBytes(int64(v.DecodedSize)))
+		} else {
+			fmt.Fprintf(&b, "Size: %s\n", formatBytes(int64(v.RawSize)))
+		}
+	}
+	b.WriteString("\n")
+	if v.DecodedValue != "" {
+		b.WriteString(v.DecodedValue)
+	} else {
+		b.WriteString("(unable to decode protobuf payload)")
+	}
+	return b.String()
+}
+
+func (m Model) detailMaxScroll() int {
+	maxVisible := detailMaxVisible(m.Height)
 	totalLines := m.detailContentLines()
-	maxScroll := totalLines - maxVisible
-	if maxScroll < 0 {
+	if totalLines <= maxVisible {
 		return 0
 	}
-	return maxScroll
+	// Match scrollValueLines at scroll=0: one slot reserved for the bottom hint.
+	// detailMaxVisible is always >= 5, so maxVisible-1 is always usable content.
+	return totalLines - (maxVisible - 1)
 }
 
 func (m Model) viewAddKey() string {

--- a/internal/ui/view_keys_preview.go
+++ b/internal/ui/view_keys_preview.go
@@ -268,6 +268,39 @@ func (m Model) formatPreviewValue(maxWidth, maxLines int) string {
 	case types.KeyTypeHyperLogLog:
 		lines = append(lines, normalStyle.Render(fmt.Sprintf("Estimated cardinality: %d", m.PreviewValue.HLLCount)))
 
+	case types.KeyTypeProtobuf:
+		format := m.PreviewValue.DecodedFormat
+		if format == "" {
+			format = "protobuf"
+		}
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("Format: %s", format)))
+		if m.PreviewValue.RawSize > 0 {
+			if m.PreviewValue.DecodedSize > 0 && m.PreviewValue.DecodedSize != m.PreviewValue.RawSize {
+				lines = append(lines, dimStyle.Render(fmt.Sprintf("Size: %s → %s",
+					formatBytes(int64(m.PreviewValue.RawSize)),
+					formatBytes(int64(m.PreviewValue.DecodedSize)))))
+			} else {
+				lines = append(lines, dimStyle.Render(fmt.Sprintf("Size: %s", formatBytes(int64(m.PreviewValue.RawSize)))))
+			}
+		}
+		lines = append(lines, "")
+		body := m.PreviewValue.DecodedValue
+		if body == "" {
+			lines = append(lines, dimStyle.Render("(unable to decode)"))
+			break
+		}
+		valueLines := strings.Split(body, "\n")
+		for i, line := range valueLines {
+			if i >= maxLines-3 {
+				lines = append(lines, dimStyle.Render(fmt.Sprintf("... (%d more lines)", len(valueLines)-i)))
+				break
+			}
+			if len(line) > maxWidth {
+				line = line[:maxWidth-3] + "..."
+			}
+			lines = append(lines, colorizeProtobufLine(line))
+		}
+
 	case types.KeyTypeBitmap:
 		lines = append(lines, dimStyle.Render(fmt.Sprintf("Bit count: %d", m.PreviewValue.BitCount)))
 		lines = append(lines, "")

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -339,6 +339,11 @@ func TestFormatPreviewValue(t *testing.T) {
 		{"bitmap with positions", types.RedisValue{Type: types.KeyTypeBitmap, BitCount: 3, BitPositions: []int64{1, 2, 3}}},
 		{"bitmap overflow positions", types.RedisValue{Type: types.KeyTypeBitmap, BitPositions: make([]int64, 30)}},
 		{"bitmap empty", types.RedisValue{Type: types.KeyTypeBitmap}},
+		{"protobuf", types.RedisValue{Type: types.KeyTypeProtobuf, DecodedFormat: "s2+protobuf", DecodedValue: "1: \"menu\"\n2: 42\n", RawSize: 100, DecodedSize: 400}},
+		{"protobuf empty decode", types.RedisValue{Type: types.KeyTypeProtobuf, RawSize: 10}},
+		{"protobuf long lines", types.RedisValue{Type: types.KeyTypeProtobuf, DecodedFormat: "protobuf", DecodedValue: strings.Repeat("1: \"x\"\n", 40), RawSize: 50, DecodedSize: 50}},
+		{"protobuf wide line", types.RedisValue{Type: types.KeyTypeProtobuf, DecodedFormat: "protobuf", DecodedValue: "1: \"" + strings.Repeat("w", 200) + "\"\n", RawSize: 20, DecodedSize: 20}},
+		{"protobuf same size preview", types.RedisValue{Type: types.KeyTypeProtobuf, DecodedFormat: "", DecodedValue: "1: 1\n", RawSize: 8, DecodedSize: 8}},
 		{"empty geo", types.RedisValue{Type: types.KeyTypeGeo}},
 		{"geo", types.RedisValue{Type: types.KeyTypeGeo, GeoValue: []types.GeoMember{{Name: "sf", Longitude: -122.4, Latitude: 37.7}}}},
 		{"geo long name", types.RedisValue{Type: types.KeyTypeGeo, GeoValue: []types.GeoMember{{Name: strings.Repeat("x", 100)}}}},
@@ -366,7 +371,7 @@ func TestViewKeyDetail(t *testing.T) {
 	types_ := []types.KeyType{
 		types.KeyTypeString, types.KeyTypeList, types.KeyTypeSet,
 		types.KeyTypeZSet, types.KeyTypeHash, types.KeyTypeStream,
-		types.KeyTypeJSON, types.KeyTypeHyperLogLog, types.KeyTypeBitmap, types.KeyTypeGeo,
+		types.KeyTypeJSON, types.KeyTypeHyperLogLog, types.KeyTypeBitmap, types.KeyTypeGeo, types.KeyTypeProtobuf,
 	}
 	for _, kt := range types_ {
 		t.Run(string(kt), func(t *testing.T) {
@@ -432,6 +437,86 @@ func TestViewKeyDetail(t *testing.T) {
 		m.CurrentValue = types.RedisValue{Type: types.KeyTypeBitmap, BitCount: 0}
 		assertNonEmpty(t, "empty bits", m.viewKeyDetail())
 	})
+	t.Run("bitmap capped positions", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.CurrentKey = &types.RedisKey{Key: "foo", Type: types.KeyTypeBitmap}
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeBitmap, BitCount: 10, BitPositions: []int64{0, 1, 2}}
+		out := m.viewKeyDetail()
+		if !strings.Contains(out, "more") {
+			t.Error("expected truncated bit positions message")
+		}
+	})
+	t.Run("protobuf decoded", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.CurrentKey = &types.RedisKey{Key: "menu", Type: types.KeyTypeProtobuf}
+		m.CurrentValue = types.RedisValue{
+			Type:          types.KeyTypeProtobuf,
+			DecodedFormat: "s2+protobuf",
+			DecodedValue:  "1: \"menu-id\"\n2: 7\n",
+			RawSize:       100,
+			DecodedSize:   400,
+		}
+		out := m.viewKeyDetail()
+		if !strings.Contains(out, "s2+protobuf") {
+			t.Error("expected format label in detail view")
+		}
+		if !strings.Contains(out, "menu-id") {
+			t.Error("expected decoded body in detail view")
+		}
+	})
+	t.Run("protobuf same size", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.CurrentKey = &types.RedisKey{Key: "menu", Type: types.KeyTypeProtobuf}
+		m.CurrentValue = types.RedisValue{
+			Type:          types.KeyTypeProtobuf,
+			DecodedFormat: "protobuf",
+			DecodedValue:  "1: 1\n",
+			RawSize:       20,
+			DecodedSize:   20,
+		}
+		assertNonEmpty(t, "proto same size", m.viewKeyDetail())
+	})
+	t.Run("protobuf empty body", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.CurrentKey = &types.RedisKey{Key: "menu", Type: types.KeyTypeProtobuf}
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeProtobuf}
+		out := m.viewKeyDetail()
+		if !strings.Contains(out, "unable to decode") {
+			t.Error("expected unable-to-decode message")
+		}
+	})
+	t.Run("protobuf selected line band", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Width = 120
+		m.Height = 40
+		m.CurrentKey = &types.RedisKey{Key: "menu", Type: types.KeyTypeProtobuf}
+		m.CurrentValue = types.RedisValue{
+			Type:          types.KeyTypeProtobuf,
+			DecodedFormat: "protobuf",
+			DecodedValue:  strings.Repeat("1: \"item\"\n", 80),
+			RawSize:       10,
+			DecodedSize:   10,
+		}
+		m.DetailCursor = 40
+		m.DetailScroll = 30
+		out := m.viewKeyDetail()
+		if !strings.Contains(out, "item") {
+			t.Error("expected content with selection")
+		}
+		if !strings.Contains(out, "more lines") {
+			t.Error("expected scroll hints when cursor mid-body")
+		}
+		_ = out
+	})
+	t.Run("string selected line band", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Width = 120
+		m.Height = 40
+		m.CurrentKey = &types.RedisKey{Key: "s", Type: types.KeyTypeString}
+		m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: "line1\nline2\nline3"}
+		m.DetailCursor = 1
+		assertNonEmpty(t, "string select", m.viewKeyDetail())
+	})
 	t.Run("long value scrolls", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		m.CurrentKey = &types.RedisKey{Key: "foo", Type: types.KeyTypeString}
@@ -463,9 +548,38 @@ func TestViewKeyDetail(t *testing.T) {
 
 func TestDetailContentLines(t *testing.T) {
 	m, _, _ := newTestModel(t)
+	m.Width = 120
+	m.Height = 40
 	m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: "a\nb\nc"}
 	if n := m.detailContentLines(); n < 1 {
 		t.Errorf("expected >= 1, got %d", n)
+	}
+	m.CurrentValue = types.RedisValue{
+		Type:          types.KeyTypeProtobuf,
+		DecodedFormat: "s2+protobuf",
+		DecodedValue:  strings.Repeat("1: \"x\"\n", 100),
+		RawSize:       50,
+		DecodedSize:   200,
+	}
+	if n := m.detailContentLines(); n < 10 {
+		t.Errorf("protobuf lines = %d, want many", n)
+	}
+	if max := m.detailMaxScroll(); max <= 0 {
+		t.Errorf("expected positive max scroll for long protobuf, got %d", max)
+	}
+	m.Height = 8
+	if n := m.detailMaxScroll(); n < 0 {
+		t.Errorf("tiny height scroll = %d", n)
+	}
+	// Force avail clamp path (detailMaxVisible floors at 5, so maxVisible-1 is always >=4
+	// for normal sizes; exercise via huge content anyway).
+	m.Height = detailChromeLines + 1
+	_ = m.detailMaxScroll()
+	// short value → zero scroll
+	m.CurrentValue = types.RedisValue{Type: types.KeyTypeString, StringValue: "hi"}
+	m.Height = 40
+	if n := m.detailMaxScroll(); n != 0 {
+		t.Errorf("short value max scroll = %d", n)
 	}
 }
 
@@ -473,7 +587,7 @@ func TestDetailValueString(t *testing.T) {
 	types_ := []types.KeyType{
 		types.KeyTypeString, types.KeyTypeList, types.KeyTypeSet,
 		types.KeyTypeZSet, types.KeyTypeHash, types.KeyTypeStream,
-		types.KeyTypeJSON, types.KeyTypeHyperLogLog, types.KeyTypeBitmap, types.KeyTypeGeo,
+		types.KeyTypeJSON, types.KeyTypeHyperLogLog, types.KeyTypeBitmap, types.KeyTypeGeo, types.KeyTypeProtobuf,
 	}
 	for _, kt := range types_ {
 		t.Run(string(kt), func(t *testing.T) {

--- a/internal/ui/view_utils.go
+++ b/internal/ui/view_utils.go
@@ -12,41 +12,46 @@ import (
 )
 
 var (
-	titleStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")).MarginBottom(1)
-	headerStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
-	normalStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
-	selectedStyle = lipgloss.NewStyle().Bold(true).Background(lipgloss.Color("39")).Foreground(lipgloss.Color("0"))
+	titleStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")).MarginBottom(1)
+	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
+	normalStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
+	// selectedStyle matches phoenix TUI: bold dark text on accent cyan/blue band.
+	selectedStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("16")).Background(lipgloss.Color("39"))
 	keyStyle      = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
 	descStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
 	errorStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
 	successStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
-	dimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	helpStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	dimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	helpStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("246"))
+	// metaDimStyle is brighter than dimStyle for Format/Size headers and scroll hints.
+	metaDimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("250"))
 
 	// Pre-allocated type-color styles to avoid per-frame allocations
 	typeStyleMap = map[types.KeyType]lipgloss.Style{
-		types.KeyTypeString: lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
-		types.KeyTypeList:   lipgloss.NewStyle().Foreground(lipgloss.Color("3")),
-		types.KeyTypeSet:    lipgloss.NewStyle().Foreground(lipgloss.Color("4")),
-		types.KeyTypeZSet:   lipgloss.NewStyle().Foreground(lipgloss.Color("5")),
-		types.KeyTypeHash:   lipgloss.NewStyle().Foreground(lipgloss.Color("6")),
+		types.KeyTypeString:      lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
+		types.KeyTypeList:        lipgloss.NewStyle().Foreground(lipgloss.Color("3")),
+		types.KeyTypeSet:         lipgloss.NewStyle().Foreground(lipgloss.Color("4")),
+		types.KeyTypeZSet:        lipgloss.NewStyle().Foreground(lipgloss.Color("5")),
+		types.KeyTypeHash:        lipgloss.NewStyle().Foreground(lipgloss.Color("6")),
 		types.KeyTypeStream:      lipgloss.NewStyle().Foreground(lipgloss.Color("13")),
 		types.KeyTypeJSON:        lipgloss.NewStyle().Foreground(lipgloss.Color("208")),
 		types.KeyTypeHyperLogLog: lipgloss.NewStyle().Foreground(lipgloss.Color("9")),
 		types.KeyTypeBitmap:      lipgloss.NewStyle().Foreground(lipgloss.Color("12")),
 		types.KeyTypeGeo:         lipgloss.NewStyle().Foreground(lipgloss.Color("10")),
+		types.KeyTypeProtobuf:    lipgloss.NewStyle().Foreground(lipgloss.Color("141")),
 	}
 	typeStyleBoldMap = map[types.KeyType]lipgloss.Style{
-		types.KeyTypeString: lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true),
-		types.KeyTypeList:   lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true),
-		types.KeyTypeSet:    lipgloss.NewStyle().Foreground(lipgloss.Color("4")).Bold(true),
-		types.KeyTypeZSet:   lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true),
-		types.KeyTypeHash:   lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true),
+		types.KeyTypeString:      lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true),
+		types.KeyTypeList:        lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true),
+		types.KeyTypeSet:         lipgloss.NewStyle().Foreground(lipgloss.Color("4")).Bold(true),
+		types.KeyTypeZSet:        lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true),
+		types.KeyTypeHash:        lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true),
 		types.KeyTypeStream:      lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Bold(true),
 		types.KeyTypeJSON:        lipgloss.NewStyle().Foreground(lipgloss.Color("208")).Bold(true),
 		types.KeyTypeHyperLogLog: lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Bold(true),
 		types.KeyTypeBitmap:      lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true),
 		types.KeyTypeGeo:         lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true),
+		types.KeyTypeProtobuf:    lipgloss.NewStyle().Foreground(lipgloss.Color("141")).Bold(true),
 	}
 	defaultTypeStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
 	defaultTypeStyleBold = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)
@@ -152,6 +157,16 @@ func formatPossibleJSON(s string) string {
 	return s
 }
 
+// Shared syntax-highlight styles (jq-style).
+var (
+	jsonKeyStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))  // Blue for keys / field numbers
+	stringValueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("34"))  // Green for strings
+	jsonNumberStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("33"))  // Yellow for numbers
+	boolStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("35"))  // Magenta for booleans
+	jsonNullStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("90"))  // Gray for null
+	bracketStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))  // White for brackets
+)
+
 // colorizeJSON adds jq-style syntax highlighting to JSON
 func colorizeJSON(s string) string {
 	var result strings.Builder
@@ -159,14 +174,6 @@ func colorizeJSON(s string) string {
 	escaped := false
 	isKey := false
 	afterColon := false
-
-	// jq-style colors
-	jsonKeyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("39"))     // Blue for keys
-	stringStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("34"))      // Green for string values
-	jsonNumberStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("33"))  // Yellow for numbers
-	boolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("35"))        // Magenta for booleans
-	jsonNullStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("90"))    // Gray for null
-	bracketStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("15"))     // White for brackets
 
 	i := 0
 	for i < len(s) {
@@ -197,7 +204,7 @@ func colorizeJSON(s string) string {
 					if isKey {
 						result.WriteString(jsonKeyStyle.Render(str))
 					} else {
-						result.WriteString(stringStyle.Render(str))
+						result.WriteString(stringValueStyle.Render(str))
 					}
 					i = end + 1
 					inString = false
@@ -321,6 +328,226 @@ func isInArrayContext(s string, pos int) bool {
 		}
 	}
 	return false
+}
+
+// colorizeProtobuf highlights schema-less protobuf text (field numbers, strings, numbers, braces).
+func colorizeProtobuf(s string) string {
+	if s == "" {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = colorizeProtobufLine(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// colorizeProtobufLine highlights a single protobuf decode_raw line.
+func colorizeProtobufLine(line string) string {
+	indentLen := 0
+	for indentLen < len(line) && line[indentLen] == ' ' {
+		indentLen++
+	}
+	indent := line[:indentLen]
+	rest := line[indentLen:]
+	if rest == "" {
+		return line
+	}
+
+	switch {
+	case strings.HasPrefix(rest, "Format:"), strings.HasPrefix(rest, "Size:"):
+		return metaDimStyle.Render(line)
+	case strings.HasPrefix(rest, "…"), strings.HasPrefix(rest, "↑"), strings.HasPrefix(rest, "↓"):
+		return metaDimStyle.Render(line)
+	case strings.HasPrefix(rest, "("):
+		return metaDimStyle.Render(line)
+	case rest == "{" || rest == "}":
+		return indent + bracketStyle.Render(rest)
+	}
+
+	colon := strings.IndexByte(rest, ':')
+	if colon <= 0 {
+		return line
+	}
+	numPart := rest[:colon]
+	for _, c := range numPart {
+		if c < '0' || c > '9' {
+			return line
+		}
+	}
+
+	valPart := ""
+	if colon+1 < len(rest) {
+		if rest[colon+1] == ' ' {
+			valPart = rest[colon+2:]
+		} else {
+			valPart = rest[colon+1:]
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString(indent)
+	b.WriteString(jsonKeyStyle.Render(numPart))
+	b.WriteString(": ")
+	switch {
+	case valPart == "{" || valPart == "}":
+		b.WriteString(bracketStyle.Render(valPart))
+	case strings.HasPrefix(valPart, `"`):
+		b.WriteString(stringValueStyle.Render(valPart))
+	case strings.HasPrefix(valPart, "<"):
+		b.WriteString(metaDimStyle.Render(valPart))
+	case valPart != "":
+		b.WriteString(jsonNumberStyle.Render(valPart))
+	}
+	return b.String()
+}
+
+// padRight pads plain text to width with trailing spaces (for full-width selection bands).
+func padRight(s string, width int) string {
+	n := len([]rune(s))
+	if n >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-n)
+}
+
+// truncateRunes truncates plain text to at most width runes.
+func truncateRunes(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= width {
+		return s
+	}
+	if width <= 1 {
+		return string(runes[:width])
+	}
+	return string(runes[:width-1]) + "…"
+}
+
+// wrapPlainLines hard-wraps lines to width so scroll counts match the rendered box.
+func wrapPlainLines(lines []string, width int) []string {
+	if width < 8 {
+		width = 8
+	}
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			out = append(out, "")
+			continue
+		}
+		runes := []rune(line)
+		for len(runes) > width {
+			out = append(out, string(runes[:width]))
+			runes = runes[width:]
+		}
+		out = append(out, string(runes))
+	}
+	return out
+}
+
+// detailBoxWidth is the centered detail value box width for the current terminal size.
+func detailBoxWidth(width int) int {
+	boxWidth := width * 3 / 5
+	boxWidth = max(boxWidth, 50)
+	boxWidth = min(boxWidth, width-6)
+	return boxWidth
+}
+
+// detailContentWidth is the usable text width inside the value box (excludes padding).
+func detailContentWidth(boxWidth int) int {
+	w := boxWidth - 4 // Padding(1, 2) left+right
+	if w < 20 {
+		return 20
+	}
+	return w
+}
+
+// detailChromeLines is vertical space used by title, meta, borders, padding, and help.
+const detailChromeLines = 16
+
+// detailMaxVisible returns how many content lines fit in the value box.
+func detailMaxVisible(height int) int {
+	maxVisible := height - detailChromeLines
+	if maxVisible < 5 {
+		return 5
+	}
+	return maxVisible
+}
+
+// scrollValueLines windows lines into maxVisible slots, reserving space for scroll hints.
+func scrollValueLines(valueLines []string, scroll, maxVisible int) (visible []string, topHint, bottomHint string, clampedScroll int) {
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
+	clampedScroll = max(scroll, 0)
+	total := len(valueLines)
+	if total <= maxVisible {
+		return valueLines, "", "", 0
+	}
+
+	// Content rows available after reserving hint rows inside the box.
+	// While not at EOF we always reserve 1 for "↓ more"; when scrolled, also 1 for "↑ more".
+	contentRows := func(scrolled bool) int {
+		n := maxVisible - 1
+		if scrolled {
+			n--
+		}
+		return max(n, 1)
+	}
+
+	avail := contentRows(clampedScroll > 0)
+	maxScroll := total - avail
+	clampedScroll = min(clampedScroll, maxScroll)
+	avail = contentRows(clampedScroll > 0)
+	end := min(clampedScroll+avail, total)
+
+	// At EOF drop the bottom hint and fill with content.
+	if end >= total {
+		rows := maxVisible
+		if clampedScroll > 0 {
+			rows--
+		}
+		end = min(clampedScroll+max(rows, 1), total)
+	}
+
+	visible = valueLines[clampedScroll:end]
+	if clampedScroll > 0 {
+		topHint = metaDimStyle.Render(fmt.Sprintf("↑ %d more lines above", clampedScroll))
+	}
+	if end < total {
+		bottomHint = metaDimStyle.Render(fmt.Sprintf("↓ %d more lines below", total-end))
+	}
+	return visible, topHint, bottomHint, clampedScroll
+}
+
+// ensureDetailCursorVisible adjusts DetailScroll so DetailCursor stays in the viewport.
+func ensureDetailCursorVisible(cursor, scroll, total, maxVisible int) (int, int) {
+	if total <= 0 {
+		return 0, 0
+	}
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor >= total {
+		cursor = total - 1
+	}
+	// Worst-case content rows when both scroll hints are shown.
+	window := maxVisible - 2
+	if window < 1 {
+		window = 1
+	}
+	if cursor < scroll {
+		scroll = cursor
+	}
+	if cursor >= scroll+window {
+		scroll = cursor - window + 1
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+	return cursor, scroll
 }
 
 func (m Model) renderModal(content string) string {

--- a/internal/ui/view_utils.go
+++ b/internal/ui/view_utils.go
@@ -15,7 +15,7 @@ var (
 	titleStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")).MarginBottom(1)
 	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("15"))
 	normalStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
-	// selectedStyle matches phoenix TUI: bold dark text on accent cyan/blue band.
+	// selectedStyle: bold dark text on accent cyan/blue band for the active detail line.
 	selectedStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("16")).Background(lipgloss.Color("39"))
 	keyStyle      = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
 	descStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))

--- a/internal/ui/view_utils_test.go
+++ b/internal/ui/view_utils_test.go
@@ -85,6 +85,177 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
+func TestColorizeProtobuf(t *testing.T) {
+	if colorizeProtobuf("") != "" {
+		t.Error("empty should stay empty")
+	}
+	in := "Format: s2+protobuf\nSize: 1 KB\n\n1: \"menu\"\n2: 7\n3: {\n  1: \"cat\"\n  4: 0xab\n  5: <3 bytes>\n}\n… truncated\n(unable to decode)\nnot-a-field\n"
+	out := colorizeProtobuf(in)
+	if !strings.Contains(out, "menu") || !strings.Contains(out, "Format:") {
+		t.Errorf("colorize lost content: %q", out)
+	}
+	// field line with no space after colon
+	if got := colorizeProtobufLine("1:\"x\""); !strings.Contains(got, "x") {
+		t.Errorf("no-space colon: %q", got)
+	}
+	if got := colorizeProtobufLine("  }"); !strings.Contains(got, "}") {
+		t.Errorf("brace: %q", got)
+	}
+	if got := colorizeProtobufLine("↑ 3 more"); !strings.Contains(got, "↑") {
+		t.Errorf("hint: %q", got)
+	}
+	if got := colorizeProtobufLine("12"); got != "12" {
+		t.Errorf("non-field passthrough: %q", got)
+	}
+	if got := colorizeProtobufLine("ab: 1"); got != "ab: 1" {
+		t.Errorf("non-numeric field: %q", got)
+	}
+	if got := colorizeProtobufLine(""); got != "" {
+		t.Errorf("empty line: %q", got)
+	}
+	if got := colorizeProtobufLine("1: "); !strings.Contains(got, "1") {
+		t.Errorf("empty value: %q", got)
+	}
+}
+
+func TestWrapPlainLines(t *testing.T) {
+	got := wrapPlainLines([]string{"", "hello-world-extra"}, 8)
+	if len(got) < 3 {
+		t.Fatalf("expected wraps, got %v", got)
+	}
+	if got[0] != "" || got[1] != "hello-wo" {
+		t.Errorf("unexpected wrap: %v", got)
+	}
+	// width below floor clamps to 8
+	got = wrapPlainLines([]string{"abcdefghij"}, 2)
+	if len(got) != 2 || got[0] != "abcdefgh" {
+		t.Errorf("narrow clamp wrap got=%v", got)
+	}
+}
+
+func TestDetailLayoutHelpers(t *testing.T) {
+	if w := detailBoxWidth(200); w < 50 || w > 194 {
+		t.Errorf("detailBoxWidth(200)=%d", w)
+	}
+	if w := detailContentWidth(40); w != 36 {
+		t.Errorf("content width=%d", w)
+	}
+	if w := detailContentWidth(10); w != 20 {
+		t.Errorf("min content width=%d", w)
+	}
+	if n := detailMaxVisible(10); n != 5 {
+		t.Errorf("min visible=%d", n)
+	}
+	if n := detailMaxVisible(40); n != 24 {
+		t.Errorf("visible=%d", n)
+	}
+}
+
+func TestPadRightTruncateRunes(t *testing.T) {
+	if got := padRight("ab", 5); got != "ab   " {
+		t.Errorf("padRight = %q", got)
+	}
+	if got := padRight("abcdef", 3); got != "abcdef" {
+		t.Errorf("padRight no-op = %q", got)
+	}
+	if got := truncateRunes("hello", 3); got != "he…" {
+		t.Errorf("truncateRunes = %q", got)
+	}
+	if got := truncateRunes("hi", 5); got != "hi" {
+		t.Errorf("truncate short = %q", got)
+	}
+	if got := truncateRunes("hello", 0); got != "" {
+		t.Errorf("truncate 0 = %q", got)
+	}
+	if got := truncateRunes("hello", 1); got != "h" {
+		t.Errorf("truncate 1 = %q", got)
+	}
+}
+
+func TestEnsureDetailCursorVisible(t *testing.T) {
+	c, s := ensureDetailCursorVisible(0, 0, 0, 10)
+	if c != 0 || s != 0 {
+		t.Errorf("empty: %d %d", c, s)
+	}
+	c, s = ensureDetailCursorVisible(-1, 0, 10, 5)
+	if c != 0 {
+		t.Errorf("neg cursor: %d", c)
+	}
+	c, s = ensureDetailCursorVisible(99, 0, 10, 5)
+	if c != 9 {
+		t.Errorf("clamp high: %d", c)
+	}
+	c, s = ensureDetailCursorVisible(2, 5, 20, 5)
+	if s != 2 {
+		t.Errorf("scroll up to cursor: s=%d", s)
+	}
+	c, s = ensureDetailCursorVisible(15, 0, 20, 5)
+	if s != 13 {
+		t.Errorf("scroll down to cursor: s=%d want 13", s)
+	}
+	// tiny maxVisible → window floors at 1; negative scroll clamps
+	c, s = ensureDetailCursorVisible(0, -5, 3, 1)
+	if s != 0 || c != 0 {
+		t.Errorf("tiny window: c=%d s=%d", c, s)
+	}
+	_ = c
+}
+
+func TestScrollValueLines(t *testing.T) {
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = string(rune('a' + i%26))
+	}
+	// fits
+	vis, top, bot, sc := scrollValueLines(lines[:3], 0, 10)
+	if len(vis) != 3 || top != "" || bot != "" || sc != 0 {
+		t.Errorf("fit: vis=%d top=%q bot=%q sc=%d", len(vis), top, bot, sc)
+	}
+	// overflow from top
+	vis, top, bot, sc = scrollValueLines(lines, 0, 5)
+	if sc != 0 || top != "" || bot == "" || len(vis) == 0 {
+		t.Errorf("top: vis=%d top=%q bot=%q sc=%d", len(vis), top, bot, sc)
+	}
+	// overflow mid
+	vis, top, bot, sc = scrollValueLines(lines, 5, 5)
+	if sc != 5 || top == "" || bot == "" {
+		t.Errorf("mid: vis=%d top=%q bot=%q sc=%d", len(vis), top, bot, sc)
+	}
+	// clamp high scroll — should land near EOF with no bottom hint
+	vis, top, bot, sc = scrollValueLines(lines, 999, 5)
+	if sc >= 20 {
+		t.Errorf("scroll not clamped: %d", sc)
+	}
+	if bot != "" {
+		t.Errorf("expected no bottom hint at EOF, got %q (sc=%d vis=%d)", bot, sc, len(vis))
+	}
+	if top == "" {
+		t.Error("expected top hint when scrolled to end")
+	}
+	// negative scroll
+	_, _, _, sc = scrollValueLines(lines, -3, 5)
+	if sc != 0 {
+		t.Errorf("neg scroll=%d", sc)
+	}
+	// tiny / zero maxVisible
+	vis, _, bot, _ = scrollValueLines(lines, 0, 1)
+	if len(vis) < 1 || bot == "" {
+		t.Errorf("tiny window vis=%d bot=%q", len(vis), bot)
+	}
+	vis, _, _, _ = scrollValueLines(lines, 2, 0)
+	if len(vis) < 1 {
+		t.Error("zero maxVisible should still show a line")
+	}
+	// single-line reclaim at EOF with top hint
+	_, top, bot, sc = scrollValueLines(lines, 19, 2)
+	if sc > 19 {
+		t.Errorf("eof scroll=%d", sc)
+	}
+	_ = top
+	_ = bot
+	_ = vis
+}
+
 func TestParseLogEntry(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Context

Binary Redis string values that are s2-compressed protobuf were misclassified as bitmaps and rendered as hundreds of thousands of set-bit positions. This adds schema-less protobuf decoding with a readable, colorized detail view so those keys are inspectable without leaving the TUI.

## Demo

```bash
make build
./bin/redis-tui -h localhost -p 6379
```

1. Open a binary string key that holds s2-compressed protobuf (for example a large menu/catalog cache blob).
2. Confirm **Type** is `protobuf` (not `bitmap`).
3. Detail pane shows `Format: s2+protobuf`, compressed → decoded size, and field-numbered structure.
4. Use `j`/`k` to move the blue selection band through lines.

## Testing

- `go test -race ./...`
- `make test-cover-check` (100% function coverage)
- Live check against local Redis keys with s2+protobuf payloads

## Changes

- Detect string subtypes in order: HyperLogLog → s2/protobuf → bitmap (`internal/redis/operations.go`, `enumeration.go`, `io.go`)
- New schema-less decoder: s2 decompress + wire-format pretty-print (`internal/decode/`)
- New `protobuf` key type with decoded metadata on `RedisValue` (`internal/types/redis.go`)
- Colorized detail/preview rendering, brighter meta text, full-width blue line selection, and fixed bottom chrome/scroll budget (`internal/ui/`)
- Cap bitmap bit-position materialization to avoid huge false-positive displays
- Deps: `github.com/klauspost/compress`, `google.golang.org/protobuf`

## Notes

- Decoding is schema-less (`protoc --decode_raw` style); field numbers only, no `.proto` required
- Pretty-print is size-capped so multi-MB values stay usable in the terminal
- Protobuf keys are read-only in the detail view (`y` copies decoded text)
