### PR TITLE
fix: classify protobuf on SCAN and preview

### DIFF
--- a/internal/redis/enumeration.go
+++ b/internal/redis/enumeration.go
@@ -108,6 +108,10 @@ const (
 	// (via GETRANGE) to detect HLL/protobuf/bitmap subtypes without transferring
 	// the full value on every scan page.
 	subtypeProbeBytes = 256
+	// subtypeFullFetchMax is the largest string we will fully GET during scan
+	// classification when a short probe looks binary but is not yet classifiable
+	// (e.g. s2-compressed protobuf needs the complete blob to decode).
+	subtypeFullFetchMax int64 = 512 * 1024
 )
 
 // ScanKeysWithRegex scans keys using regex pattern with early termination.
@@ -420,8 +424,10 @@ func (c *Client) GetKeyPrefixes(separator string, maxDepth int) ([]string, error
 }
 
 // detectStringSubtypes checks string-typed keys for HLL/protobuf/bitmap subtypes
-// using a pipeline GETRANGE of the first subtypeProbeBytes bytes — a full GET
-// would transfer entire (possibly huge) values on every scan page.
+// using a pipeline GETRANGE of the first subtypeProbeBytes bytes. Incomplete
+// binary probes that may be s2-compressed protobuf are re-fetched in full when
+// the key is under subtypeFullFetchMax so the list type is correct without
+// selecting the key.
 func (c *Client) detectStringSubtypes(keys []types.RedisKey) []types.RedisKey {
 	// Collect indices of string keys
 	var stringIdxs []int
@@ -441,6 +447,9 @@ func (c *Client) detectStringSubtypes(keys []types.RedisKey) []types.RedisKey {
 	}
 	_, _ = pipe.Exec(c.ctx)
 
+	// Ambiguous: probe filled the window and looked binary but was not yet
+	// classifiable (common for s2+protobuf — needs the whole blob).
+	var ambiguous []int
 	for j, idx := range stringIdxs {
 		val, err := getCmds[j].Result()
 		if err != nil {
@@ -459,9 +468,58 @@ func (c *Client) detectStringSubtypes(keys []types.RedisKey) []types.RedisKey {
 		if len(val) == subtypeProbeBytes {
 			binary = isBinaryPrefix(val)
 		}
-		// Incomplete probes of large binary values may be compressed protobuf
-		// that only decodes with the full payload — leave type as string.
-		if binary && len(val) < subtypeProbeBytes {
+		if !binary {
+			continue
+		}
+		if len(val) < subtypeProbeBytes {
+			// Complete short binary value → bitmap.
+			keys[idx].Type = types.KeyTypeBitmap
+			continue
+		}
+		ambiguous = append(ambiguous, idx)
+	}
+
+	if len(ambiguous) == 0 {
+		return keys
+	}
+
+	// Second pass: STRLEN, then full GET only for small-enough binary keys.
+	pipe = c.pipeline()
+	lenCmds := make([]*redis.IntCmd, len(ambiguous))
+	for j, idx := range ambiguous {
+		lenCmds[j] = pipe.StrLen(c.ctx, keys[idx].Key)
+	}
+	_, _ = pipe.Exec(c.ctx)
+
+	var fetchIdxs []int
+	for j, idx := range ambiguous {
+		n, err := lenCmds[j].Result()
+		if err != nil || n <= 0 || n > subtypeFullFetchMax {
+			continue
+		}
+		fetchIdxs = append(fetchIdxs, idx)
+	}
+	if len(fetchIdxs) == 0 {
+		return keys
+	}
+
+	pipe = c.pipeline()
+	fullCmds := make([]*redis.StringCmd, len(fetchIdxs))
+	for j, idx := range fetchIdxs {
+		fullCmds[j] = pipe.Get(c.ctx, keys[idx].Key)
+	}
+	_, _ = pipe.Exec(c.ctx)
+
+	for j, idx := range fetchIdxs {
+		val, err := fullCmds[j].Result()
+		if err != nil {
+			continue
+		}
+		if decode.LooksLikeProtobuf([]byte(val)) {
+			keys[idx].Type = types.KeyTypeProtobuf
+			continue
+		}
+		if isBinaryString(val) {
 			keys[idx].Type = types.KeyTypeBitmap
 		}
 	}

--- a/internal/redis/enumeration_test.go
+++ b/internal/redis/enumeration_test.go
@@ -947,9 +947,8 @@ func TestScanKeys_DetectStringSubtypes_LargeValues(t *testing.T) {
 	// the key must stay a plain string.
 	mr.Set("large:text", strings.Repeat("a", subtypeProbeBytes*2))
 
-	// Large binary value: incomplete probes stay "string" so large compressed
-	// protobuf blobs are not mislabeled as bitmaps. GetValue still classifies
-	// on open.
+	// Binary larger than the probe window but under subtypeFullFetchMax is
+	// re-fetched and classified as bitmap when not protobuf.
 	bin := make([]byte, subtypeProbeBytes*2)
 	for i := range bin {
 		bin[i] = 0xff
@@ -958,6 +957,27 @@ func TestScanKeys_DetectStringSubtypes_LargeValues(t *testing.T) {
 
 	// Short complete binary value still classifies as bitmap from the probe alone.
 	mr.Set("short:bin", string([]byte{0xff, 0xfe}))
+
+	// s2+protobuf larger than the probe window must still show as protobuf after
+	// the small full-GET follow-up (not wait until the key is selected).
+	var protoRaw []byte
+	for i := 0; i < 80; i++ {
+		s := fmt.Sprintf("item-description-padding-%04d-xxxxxxxx", i)
+		protoRaw = append(protoRaw, 0x12, byte(len(s)))
+		protoRaw = append(protoRaw, s...)
+	}
+	compressed := s2.Encode(nil, protoRaw)
+	if len(compressed) <= subtypeProbeBytes {
+		t.Fatalf("test fixture too small: compressed=%d probe=%d", len(compressed), subtypeProbeBytes)
+	}
+	mr.Set("large:s2proto", string(compressed))
+
+	// Huge binary over subtypeFullFetchMax is not fully re-fetched; stays string.
+	huge := make([]byte, int(subtypeFullFetchMax)+1024)
+	for i := range huge {
+		huge[i] = 0xab
+	}
+	mr.Set("huge:bin", string(huge))
 
 	keys, _, err := client.ScanKeys("*", 0, 100)
 	if err != nil {
@@ -970,11 +990,72 @@ func TestScanKeys_DetectStringSubtypes_LargeValues(t *testing.T) {
 	if byName["large:text"] != "string" {
 		t.Errorf("large:text type = %q, want string", byName["large:text"])
 	}
-	if byName["large:bin"] != "string" {
-		t.Errorf("large:bin type = %q, want string (incomplete probe)", byName["large:bin"])
+	if byName["large:bin"] != "bitmap" {
+		t.Errorf("large:bin type = %q, want bitmap", byName["large:bin"])
 	}
 	if byName["short:bin"] != "bitmap" {
 		t.Errorf("short:bin type = %q, want bitmap", byName["short:bin"])
+	}
+	if byName["large:s2proto"] != types.KeyTypeProtobuf {
+		t.Errorf("large:s2proto type = %q, want protobuf", byName["large:s2proto"])
+	}
+	if byName["huge:bin"] != "string" {
+		t.Errorf("huge:bin type = %q, want string (over full-fetch cap)", byName["huge:bin"])
+	}
+}
+
+func TestScanKeys_DetectStringSubtypes_HugeBinaryNoFetch(t *testing.T) {
+	client, mr := setupTestClient(t)
+	// Only oversize binary keys: second pass finds nothing to full-GET.
+	huge := make([]byte, int(subtypeFullFetchMax)+8)
+	for i := range huge {
+		huge[i] = 0xcd
+	}
+	mr.Set("only:huge", string(huge))
+	keys, _, err := client.ScanKeys("only:huge", 0, 10)
+	if err != nil {
+		t.Fatalf("ScanKeys: %v", err)
+	}
+	if len(keys) != 1 || keys[0].Type != "string" {
+		t.Fatalf("got %+v, want string", keys)
+	}
+}
+
+func TestDetectStringSubtypes_FullGetError(t *testing.T) {
+	// GETRANGE returns a full probe of binary bytes → ambiguous; STRLEN is
+	// small enough to full-GET; GET then fails and the key stays string.
+	srv := newFakeRedisServer(t)
+	probe := strings.Repeat("\xff", subtypeProbeBytes)
+	srv.setHandler(func(argv []string) string {
+		switch argv[0] {
+		case "SCAN":
+			return "*2\r\n$1\r\n0\r\n*1\r\n$1\r\nx\r\n"
+		case "TYPE":
+			return "+string\r\n"
+		case "TTL":
+			return ":-1\r\n"
+		case "GETRANGE":
+			return fmt.Sprintf("$%d\r\n%s\r\n", len(probe), probe)
+		case "STRLEN":
+			return ":512\r\n"
+		case "GET":
+			return "-ERR injected\r\n"
+		}
+		return ""
+	})
+	host, port := srv.addr()
+	c := NewClient()
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Disconnect() })
+
+	keys, _, err := c.ScanKeys("*", 0, 100)
+	if err != nil {
+		t.Fatalf("ScanKeys: %v", err)
+	}
+	if len(keys) != 1 || keys[0].Type != "string" {
+		t.Fatalf("got %+v, want string after GET error", keys)
 	}
 }
 

--- a/internal/redis/preview.go
+++ b/internal/redis/preview.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"strings"
 
+	"github.com/davidbudnick/redis-tui/internal/decode"
 	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
@@ -127,8 +128,8 @@ func markTruncated(value *types.RedisValue, total int64, fetched int) {
 	}
 }
 
-// previewString fills in a bounded string preview, including HLL and bitmap
-// subtype detection on the fetched prefix.
+// previewString fills in a bounded string preview, including HLL, protobuf, and
+// bitmap subtype detection on the fetched bytes.
 func (c *Client) previewString(key string, value *types.RedisValue) error {
 	total, err := c.cmdable().StrLen(c.ctx, key).Result()
 	if err != nil {
@@ -149,9 +150,25 @@ func (c *Client) previewString(key string, value *types.RedisValue) error {
 		return nil
 	}
 
+	// Prefer protobuf (incl. s2-compressed) over bitmap: binary probes that are
+	// really compressed menus must not be labeled as bitmaps in the list UI.
+	if decoded, ok := decode.TryBinary([]byte(val)); ok {
+		value.Type = types.KeyTypeProtobuf
+		value.DecodedValue = decoded.Text
+		value.DecodedFormat = decoded.Format
+		value.RawSize = decoded.RawSize
+		value.DecodedSize = decoded.DecodedSize
+		return nil
+	}
+
 	binary := isBinaryString(val)
 	if value.Truncated {
 		binary = isBinaryPrefix(val)
+		// Incomplete binary blob may still be compressed protobuf that only
+		// decodes with the full payload — leave type as string until GetValue.
+		if binary {
+			return nil
+		}
 	}
 	if binary {
 		value.Type = types.KeyTypeBitmap

--- a/internal/redis/preview_test.go
+++ b/internal/redis/preview_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/davidbudnick/redis-tui/internal/types"
+	"github.com/klauspost/compress/s2"
 )
 
 // ---------------------------------------------------------------------------
@@ -104,7 +105,8 @@ func TestGetValuePreview_Bitmap(t *testing.T) {
 
 func TestGetValuePreview_BitmapTruncated(t *testing.T) {
 	client, mr := setupTestClient(t)
-	// Binary value larger than the preview byte cap.
+	// Binary value larger than the preview byte cap. Incomplete binary must
+	// stay typed as string so large compressed protobuf is not mislabeled.
 	bin := make([]byte, previewMaxStringBytes+512)
 	for i := range bin {
 		bin[i] = 0xff
@@ -115,14 +117,11 @@ func TestGetValuePreview_BitmapTruncated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetValuePreview error: %v", err)
 	}
-	if v.Type != types.KeyTypeBitmap {
-		t.Errorf("Type = %q, want bitmap", v.Type)
+	if v.Type != types.KeyTypeString {
+		t.Errorf("Type = %q, want string for truncated non-protobuf binary", v.Type)
 	}
 	if !v.Truncated {
 		t.Error("expected Truncated = true")
-	}
-	if len(v.BitPositions) != maxBitPositions {
-		t.Errorf("BitPositions length = %d, want cap %d", len(v.BitPositions), maxBitPositions)
 	}
 }
 
@@ -600,4 +599,46 @@ func BenchmarkCompareStringFetch(b *testing.B) {
 			}
 		}
 	})
+}
+
+func TestGetValuePreview_ProtobufS2(t *testing.T) {
+	client, mr := setupTestClient(t)
+	var raw []byte
+	raw = append(raw, 0x0a, 0x04)
+	raw = append(raw, []byte("menu")...)
+	compressed := s2.Encode(nil, raw)
+	mr.Set("proto:s2", string(compressed))
+	v, err := client.GetValuePreview("proto:s2")
+	if err != nil {
+		t.Fatalf("GetValuePreview: %v", err)
+	}
+	if v.Type != types.KeyTypeProtobuf {
+		t.Fatalf("Type = %q, want protobuf", v.Type)
+	}
+	if v.DecodedFormat != "s2+protobuf" {
+		t.Errorf("DecodedFormat = %q", v.DecodedFormat)
+	}
+	if !strings.Contains(v.DecodedValue, "menu") {
+		t.Errorf("DecodedValue = %q", v.DecodedValue)
+	}
+}
+
+func TestGetValuePreview_TruncatedBinaryStaysString(t *testing.T) {
+	client, mr := setupTestClient(t)
+	// Binary blob larger than previewMaxStringBytes that is not valid protobuf.
+	bin := make([]byte, previewMaxStringBytes+1024)
+	for i := range bin {
+		bin[i] = 0xff
+	}
+	mr.Set("bigbin", string(bin))
+	v, err := client.GetValuePreview("bigbin")
+	if err != nil {
+		t.Fatalf("GetValuePreview: %v", err)
+	}
+	if v.Type != types.KeyTypeString {
+		t.Fatalf("Type = %q, want string (not bitmap) for truncated binary", v.Type)
+	}
+	if !v.Truncated {
+		t.Error("expected Truncated")
+	}
 }


### PR DESCRIPTION
## Context

After the preview/perf work, s2-compressed protobuf keys were mislabeled:

1. **Preview** treated any non-UTF-8 string as a bitmap and never tried protobuf, then overwrote the list type.
2. **SCAN** only probed 256 bytes, so compressed menus stayed `string` until selected.

## Changes

- `GetValuePreview` / `previewString`: try `decode.TryBinary` before bitmap; leave truncated non-protobuf binary as `string`
- `detectStringSubtypes`: if a short probe looks binary but is incomplete, full-`GET` keys ≤512 KB and classify as protobuf/bitmap on the list (no select needed)
- Tests for preview protobuf, truncated binary, s2 scan classification, and huge-key skip path

## Testing

- `go test ./internal/redis/ -count=1`
- Local: `demo:menu:v1:*` show **protobuf** in the list without selecting first
