### PR TITLE
perf: debounce key list previews

### DIFF
--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -158,6 +158,11 @@ type SearchDebounceMsg struct {
 	Seq int
 }
 
+type PreviewDebounceMsg struct {
+	Seq int
+	Key string
+}
+
 type TTLRefreshMsg struct {
 	Keys []RedisKey
 	Err  error

--- a/internal/ui/messages_keys.go
+++ b/internal/ui/messages_keys.go
@@ -55,13 +55,18 @@ func (m Model) handleKeyValueLoadedMsg(msg types.KeyValueLoadedMsg) (tea.Model, 
 
 func (m Model) handleKeyPreviewLoadedMsg(msg types.KeyPreviewLoadedMsg) (tea.Model, tea.Cmd) {
 	if msg.Err != nil {
+		slog.Error("Failed to load key preview", "key", msg.Key, "error", msg.Err)
+		if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys) && m.Keys[m.SelectedKeyIdx].Key == msg.Key {
+			m.StatusMsg = "Error: " + msg.Err.Error()
+			m.PreviewKey = ""
+			m.PreviewValue = types.RedisValue{}
+			m.PreviewRendered = ""
+		}
 		return m, nil
 	}
-	// Only update if the key matches the currently selected key
 	if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys) && m.Keys[m.SelectedKeyIdx].Key == msg.Key {
 		m.PreviewKey = msg.Key
 		m.PreviewValue = msg.Value
-		// Pre-format string/JSON/protobuf previews once — must not run per frame.
 		m.PreviewRendered = ""
 		switch msg.Value.Type {
 		case types.KeyTypeString:
@@ -71,8 +76,6 @@ func (m Model) handleKeyPreviewLoadedMsg(msg types.KeyPreviewLoadedMsg) (tea.Mod
 		case types.KeyTypeProtobuf:
 			m.PreviewRendered = formatProtobufValue(msg.Value)
 		}
-		// On-demand type resolution: fill in type if it was not fetched during scan,
-		// or update when GetValue detected a subtype (e.g. string→hyperloglog)
 		if msg.Value.Type != "" && m.Keys[m.SelectedKeyIdx].Type != msg.Value.Type {
 			m.Keys[m.SelectedKeyIdx].Type = msg.Value.Type
 		}

--- a/internal/ui/messages_keys_test.go
+++ b/internal/ui/messages_keys_test.go
@@ -115,13 +115,39 @@ func TestHandleKeyPreviewLoadedMsg(t *testing.T) {
 			t.Errorf("expected type updated, got %v", model.Keys[0].Type)
 		}
 	})
-	t.Run("error ignored", func(t *testing.T) {
+	t.Run("error sets status for selected key", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
-		msg := types.KeyPreviewLoadedMsg{Err: errors.New("boom")}
+		m.Keys = []types.RedisKey{{Key: "foo"}}
+		m.SelectedKeyIdx = 0
+		m.PreviewKey = "foo"
+		m.PreviewValue = types.RedisValue{StringValue: "stale"}
+		m.PreviewRendered = "stale"
+		msg := types.KeyPreviewLoadedMsg{Key: "foo", Err: errors.New("boom")}
 		result, _ := m.handleKeyPreviewLoadedMsg(msg)
 		model := result.(Model)
+		if !strings.HasPrefix(model.StatusMsg, "Error:") {
+			t.Errorf("expected error status, got %q", model.StatusMsg)
+		}
 		if model.PreviewKey != "" {
-			t.Errorf("expected empty preview, got %q", model.PreviewKey)
+			t.Errorf("expected cleared PreviewKey, got %q", model.PreviewKey)
+		}
+		if model.PreviewRendered != "" {
+			t.Errorf("expected cleared PreviewRendered, got %q", model.PreviewRendered)
+		}
+	})
+	t.Run("error ignored for unselected key", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Keys = []types.RedisKey{{Key: "foo"}}
+		m.SelectedKeyIdx = 0
+		m.PreviewKey = "foo"
+		msg := types.KeyPreviewLoadedMsg{Key: "bar", Err: errors.New("boom")}
+		result, _ := m.handleKeyPreviewLoadedMsg(msg)
+		model := result.(Model)
+		if model.StatusMsg != "" {
+			t.Errorf("expected empty status, got %q", model.StatusMsg)
+		}
+		if model.PreviewKey != "foo" {
+			t.Errorf("expected preview retained, got %q", model.PreviewKey)
 		}
 	})
 	t.Run("key mismatch ignored", func(t *testing.T) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -28,6 +28,7 @@ type Model struct {
 	KeyCursor         uint64
 	KeyPattern        string
 	SearchSeq         int
+	PreviewSeq        int
 	CurrentKey        *types.RedisKey
 	CurrentValue      types.RedisValue
 	AddKeyInputs      []textinput.Model

--- a/internal/ui/screens_keys.go
+++ b/internal/ui/screens_keys.go
@@ -17,6 +17,18 @@ func createVimEditor(content string, width, height int, fileName string) *editor
 	return editor.New(content, width, height, fileName)
 }
 
+func (m *Model) debounceKeyPreview() tea.Cmd {
+	if len(m.Keys) == 0 || m.SelectedKeyIdx < 0 || m.SelectedKeyIdx >= len(m.Keys) {
+		return nil
+	}
+	m.PreviewSeq++
+	seq := m.PreviewSeq
+	key := m.Keys[m.SelectedKeyIdx].Key
+	return tea.Tick(100*time.Millisecond, func(time.Time) tea.Msg {
+		return types.PreviewDebounceMsg{Seq: seq, Key: key}
+	})
+}
+
 func (m Model) handleKeysScreen(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.Inputs.PatternInput.Focused() {
 		switch msg.String() {
@@ -54,25 +66,19 @@ func (m Model) handleKeysScreen(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "up", "k":
 		if m.SelectedKeyIdx > 0 {
 			m.SelectedKeyIdx--
-			if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys) {
-				return m, m.Cmds.LoadKeyPreview(m.Keys[m.SelectedKeyIdx].Key)
-			}
+			return m, m.debounceKeyPreview()
 		}
 	case "down", "j":
 		if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys)-1 {
 			m.SelectedKeyIdx++
-			if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys) {
-				return m, m.Cmds.LoadKeyPreview(m.Keys[m.SelectedKeyIdx].Key)
-			}
+			return m, m.debounceKeyPreview()
 		}
 	case "pgup", "ctrl+u":
 		m.SelectedKeyIdx -= 10
 		if m.SelectedKeyIdx < 0 {
 			m.SelectedKeyIdx = 0
 		}
-		if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys) {
-			return m, m.Cmds.LoadKeyPreview(m.Keys[m.SelectedKeyIdx].Key)
-		}
+		return m, m.debounceKeyPreview()
 	case "pgdown", "ctrl+d":
 		if len(m.Keys) == 0 {
 			return m, nil
@@ -81,18 +87,14 @@ func (m Model) handleKeysScreen(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.SelectedKeyIdx >= len(m.Keys) {
 			m.SelectedKeyIdx = len(m.Keys) - 1
 		}
-		if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys) {
-			return m, m.Cmds.LoadKeyPreview(m.Keys[m.SelectedKeyIdx].Key)
-		}
+		return m, m.debounceKeyPreview()
 	case "home", "g":
 		m.SelectedKeyIdx = 0
-		if len(m.Keys) > 0 {
-			return m, m.Cmds.LoadKeyPreview(m.Keys[m.SelectedKeyIdx].Key)
-		}
+		return m, m.debounceKeyPreview()
 	case "end", "G":
 		if len(m.Keys) > 0 {
 			m.SelectedKeyIdx = len(m.Keys) - 1
-			return m, m.Cmds.LoadKeyPreview(m.Keys[m.SelectedKeyIdx].Key)
+			return m, m.debounceKeyPreview()
 		}
 	case "enter":
 		if len(m.Keys) > 0 && m.SelectedKeyIdx < len(m.Keys) {

--- a/internal/ui/screens_keys_test.go
+++ b/internal/ui/screens_keys_test.go
@@ -16,6 +16,24 @@ func seedKeys(m *Model, n int) {
 	}
 }
 
+func assertPreviewDebounce(t *testing.T, cmd tea.Cmd, wantSeq int, wantKey string) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected debounce cmd")
+	}
+	msg := cmd()
+	deb, ok := msg.(types.PreviewDebounceMsg)
+	if !ok {
+		t.Fatalf("expected PreviewDebounceMsg, got %T", msg)
+	}
+	if deb.Seq != wantSeq {
+		t.Errorf("expected Seq %d, got %d", wantSeq, deb.Seq)
+	}
+	if deb.Key != wantKey {
+		t.Errorf("expected Key %q, got %q", wantKey, deb.Key)
+	}
+}
+
 func TestHandleKeysScreen_Navigation(t *testing.T) {
 	t.Run("down advances", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
@@ -25,18 +43,22 @@ func TestHandleKeysScreen_Navigation(t *testing.T) {
 		if model.SelectedKeyIdx != 1 {
 			t.Errorf("expected 1, got %d", model.SelectedKeyIdx)
 		}
-		if cmd == nil {
-			t.Error("expected preview cmd")
+		if model.PreviewSeq != 1 {
+			t.Errorf("expected PreviewSeq 1, got %d", model.PreviewSeq)
 		}
+		assertPreviewDebounce(t, cmd, 1, "b")
 	})
 	t.Run("down at bottom", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 3)
 		m.SelectedKeyIdx = 2
-		result, _ := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyDown})
+		result, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyDown})
 		model := result.(Model)
 		if model.SelectedKeyIdx != 2 {
 			t.Errorf("expected 2, got %d", model.SelectedKeyIdx)
+		}
+		if cmd != nil {
+			t.Error("expected nil cmd when selection unchanged")
 		}
 	})
 	t.Run("up decrements", func(t *testing.T) {
@@ -48,52 +70,61 @@ func TestHandleKeysScreen_Navigation(t *testing.T) {
 		if model.SelectedKeyIdx != 1 {
 			t.Errorf("expected 1, got %d", model.SelectedKeyIdx)
 		}
-		if cmd == nil {
-			t.Error("expected preview cmd")
-		}
+		assertPreviewDebounce(t, cmd, 1, "b")
 	})
 	t.Run("up at top", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 3)
-		_, _ = m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyUp})
+		result, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyUp})
+		model := result.(Model)
+		if model.SelectedKeyIdx != 0 {
+			t.Errorf("expected 0, got %d", model.SelectedKeyIdx)
+		}
+		if cmd != nil {
+			t.Error("expected nil cmd when selection unchanged")
+		}
 	})
 	t.Run("pgup", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 20)
 		m.SelectedKeyIdx = 15
-		result, _ := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyPgUp})
+		result, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyPgUp})
 		model := result.(Model)
 		if model.SelectedKeyIdx != 5 {
 			t.Errorf("expected 5, got %d", model.SelectedKeyIdx)
 		}
+		assertPreviewDebounce(t, cmd, 1, string(rune('a'+5)))
 	})
 	t.Run("pgup clamps at 0", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 5)
 		m.SelectedKeyIdx = 3
-		result, _ := m.handleKeysScreen(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
+		result, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
 		model := result.(Model)
 		if model.SelectedKeyIdx != 0 {
 			t.Errorf("expected 0, got %d", model.SelectedKeyIdx)
 		}
+		assertPreviewDebounce(t, cmd, 1, "a")
 	})
 	t.Run("pgdown", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 20)
-		result, _ := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyPgDown})
+		result, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyPgDown})
 		model := result.(Model)
 		if model.SelectedKeyIdx != 10 {
 			t.Errorf("expected 10, got %d", model.SelectedKeyIdx)
 		}
+		assertPreviewDebounce(t, cmd, 1, string(rune('a'+10)))
 	})
 	t.Run("pgdown clamps", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 5)
-		result, _ := m.handleKeysScreen(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+		result, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
 		model := result.(Model)
 		if model.SelectedKeyIdx != 4 {
 			t.Errorf("expected 4, got %d", model.SelectedKeyIdx)
 		}
+		assertPreviewDebounce(t, cmd, 1, "e")
 	})
 	t.Run("pgdown empty", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
@@ -106,17 +137,23 @@ func TestHandleKeysScreen_Navigation(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 5)
 		m.SelectedKeyIdx = 3
-		result, _ := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyHome})
+		result, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyHome})
 		model := result.(Model)
 		if model.SelectedKeyIdx != 0 {
 			t.Errorf("expected 0, got %d", model.SelectedKeyIdx)
 		}
+		assertPreviewDebounce(t, cmd, 1, "a")
 	})
 	t.Run("g home", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 5)
 		m.SelectedKeyIdx = 3
-		_, _ = m.handleKeysScreen(keyMsg('g'))
+		result, cmd := m.handleKeysScreen(keyMsg('g'))
+		model := result.(Model)
+		if model.SelectedKeyIdx != 0 {
+			t.Errorf("expected 0, got %d", model.SelectedKeyIdx)
+		}
+		assertPreviewDebounce(t, cmd, 1, "a")
 	})
 	t.Run("home empty no-cmd", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
@@ -128,22 +165,68 @@ func TestHandleKeysScreen_Navigation(t *testing.T) {
 	t.Run("end", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 5)
-		result, _ := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyEnd})
+		result, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyEnd})
 		model := result.(Model)
 		if model.SelectedKeyIdx != 4 {
 			t.Errorf("expected 4, got %d", model.SelectedKeyIdx)
 		}
+		assertPreviewDebounce(t, cmd, 1, "e")
 	})
 	t.Run("G end", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 5)
-		_, _ = m.handleKeysScreen(keyMsg('G'))
+		result, cmd := m.handleKeysScreen(keyMsg('G'))
+		model := result.(Model)
+		if model.SelectedKeyIdx != 4 {
+			t.Errorf("expected 4, got %d", model.SelectedKeyIdx)
+		}
+		assertPreviewDebounce(t, cmd, 1, "e")
 	})
 	t.Run("end empty", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		_, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyEnd})
 		if cmd != nil {
 			t.Error("expected nil cmd")
+		}
+	})
+	t.Run("rapid j increments PreviewSeq and only latest seq matters", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		seedKeys(&m, 5)
+		result, cmd1 := m.handleKeysScreen(keyMsg('j'))
+		m = result.(Model)
+		result, cmd2 := m.handleKeysScreen(keyMsg('j'))
+		m = result.(Model)
+		if m.PreviewSeq != 2 {
+			t.Errorf("expected PreviewSeq 2, got %d", m.PreviewSeq)
+		}
+		assertPreviewDebounce(t, cmd1, 1, "b")
+		assertPreviewDebounce(t, cmd2, 2, "c")
+	})
+}
+
+func TestDebounceKeyPreview(t *testing.T) {
+	t.Run("empty keys returns nil", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		if cmd := m.debounceKeyPreview(); cmd != nil {
+			t.Error("expected nil cmd")
+		}
+	})
+	t.Run("out of range returns nil", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		seedKeys(&m, 2)
+		m.SelectedKeyIdx = 5
+		if cmd := m.debounceKeyPreview(); cmd != nil {
+			t.Error("expected nil cmd")
+		}
+	})
+	t.Run("schedules debounce with key", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		seedKeys(&m, 2)
+		m.SelectedKeyIdx = 1
+		cmd := m.debounceKeyPreview()
+		assertPreviewDebounce(t, cmd, 1, "b")
+		if m.PreviewSeq != 1 {
+			t.Errorf("expected PreviewSeq 1, got %d", m.PreviewSeq)
 		}
 	})
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -38,6 +38,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case types.PreviewDebounceMsg:
+		if msg.Seq == m.PreviewSeq &&
+			len(m.Keys) > 0 &&
+			m.SelectedKeyIdx < len(m.Keys) &&
+			m.Keys[m.SelectedKeyIdx].Key == msg.Key {
+			return m, m.Cmds.LoadKeyPreview(msg.Key)
+		}
+		return m, nil
+
 	case types.TickMsg:
 		return m.handleTickMsg()
 

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -68,6 +68,55 @@ func TestUpdate_SearchDebounceMsg(t *testing.T) {
 	})
 }
 
+func TestUpdate_PreviewDebounceMsg(t *testing.T) {
+	t.Run("matching seq and key loads preview", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Keys = []types.RedisKey{{Key: "foo"}, {Key: "bar"}}
+		m.SelectedKeyIdx = 1
+		m.PreviewSeq = 3
+		_, cmd := m.Update(types.PreviewDebounceMsg{Seq: 3, Key: "bar"})
+		if cmd == nil {
+			t.Fatal("expected LoadKeyPreview cmd")
+		}
+		msg := cmd()
+		loaded, ok := msg.(types.KeyPreviewLoadedMsg)
+		if !ok {
+			t.Fatalf("expected KeyPreviewLoadedMsg, got %T", msg)
+		}
+		if loaded.Key != "bar" {
+			t.Errorf("expected key bar, got %q", loaded.Key)
+		}
+	})
+	t.Run("seq mismatch ignored", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Keys = []types.RedisKey{{Key: "foo"}}
+		m.SelectedKeyIdx = 0
+		m.PreviewSeq = 5
+		_, cmd := m.Update(types.PreviewDebounceMsg{Seq: 3, Key: "foo"})
+		if cmd != nil {
+			t.Error("expected nil cmd")
+		}
+	})
+	t.Run("key mismatch ignored", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Keys = []types.RedisKey{{Key: "foo"}}
+		m.SelectedKeyIdx = 0
+		m.PreviewSeq = 1
+		_, cmd := m.Update(types.PreviewDebounceMsg{Seq: 1, Key: "bar"})
+		if cmd != nil {
+			t.Error("expected nil cmd")
+		}
+	})
+	t.Run("empty keys ignored", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.PreviewSeq = 1
+		_, cmd := m.Update(types.PreviewDebounceMsg{Seq: 1, Key: "foo"})
+		if cmd != nil {
+			t.Error("expected nil cmd")
+		}
+	})
+}
+
 func TestUpdate_TickMsg(t *testing.T) {
 	m, _, _ := newTestModel(t)
 	_, cmd := m.Update(types.TickMsg{})
@@ -91,6 +140,7 @@ func TestUpdate_AllMessageDispatchBranches(t *testing.T) {
 		types.KeysLoadedMsg{},
 		types.KeyValueLoadedMsg{},
 		types.KeyPreviewLoadedMsg{},
+		types.PreviewDebounceMsg{},
 		types.KeyDeletedMsg{},
 		types.KeySetMsg{},
 		types.KeyRenamedMsg{},


### PR DESCRIPTION
## Summary
- Debounce key-list preview loads during fast j/k (and pgup/pgdown/home/end) navigation via `PreviewSeq` + `PreviewDebounceMsg` (100ms), mirroring the existing search debounce pattern — avoids flooding Redis with concurrent `GetValuePreview` calls
- Surface preview load errors in the status bar (`slog.Error` + `StatusMsg`) instead of swallowing them; clear stale preview state for the selected key on failure
- Keep immediate `LoadKeyPreview` after `KeysLoadedMsg` so first paint stays snappy

## Test plan
- [x] `go test -race ./internal/ui/... ./internal/types/...`
- [x] UI tests for `PreviewDebounceMsg` (stale seq ignored; matching seq+key loads preview)
- [x] Navigation tests assert debounce tick cmds (not immediate `LoadKeyPreview`) and `PreviewSeq` increments
- [x] `handleKeyPreviewLoadedMsg` error path sets `StatusMsg` and clears preview for selected key; ignores errors for unselected keys
- [x] 100% statement coverage on `debounceKeyPreview` and `handleKeyPreviewLoadedMsg`