### PR TITLE
perf: bound detail and compare fetches

### DIFF
--- a/internal/redis/io.go
+++ b/internal/redis/io.go
@@ -1,11 +1,9 @@
 package redis
 
 import (
-	"context"
 	"fmt"
 	"time"
 
-	"github.com/davidbudnick/redis-tui/internal/decode"
 	"github.com/davidbudnick/redis-tui/internal/types"
 	"github.com/redis/go-redis/v9"
 )
@@ -250,122 +248,15 @@ func (c *Client) ImportKeys(data map[string]any) (int, error) {
 	return count, nil
 }
 
-// CompareKeys compares two keys and returns their values.
-// Pipelines both TYPE commands and both value fetches to reduce round-trips from 4 to 2.
+// CompareKeys compares two keys using the same bounded GetValue path as detail.
 func (c *Client) CompareKeys(key1, key2 string) (types.RedisValue, types.RedisValue, error) {
-	// Pipeline 1: get both types
-	pipe := c.pipeline()
-	type1Cmd := pipe.Type(c.ctx, key1)
-	type2Cmd := pipe.Type(c.ctx, key2)
-	_, err := pipe.Exec(c.ctx)
-	if err != nil && err != redis.Nil {
-		return types.RedisValue{}, types.RedisValue{}, fmt.Errorf("error getting types: %w", err)
+	val1, err := c.GetValue(key1)
+	if err != nil {
+		return types.RedisValue{}, types.RedisValue{}, fmt.Errorf("error getting value for %s: %w", key1, err)
 	}
-
-	keyType1, _ := type1Cmd.Result()
-	keyType2, _ := type2Cmd.Result()
-
-	// Pipeline 2: get both values based on types
-	pipe = c.pipeline()
-	cmds1 := queueValueFetch(pipe, c.ctx, key1, keyType1)
-	cmds2 := queueValueFetch(pipe, c.ctx, key2, keyType2)
-	_, _ = pipe.Exec(c.ctx)
-
-	val1 := extractValue(keyType1, cmds1)
-	val2 := extractValue(keyType2, cmds2)
-
+	val2, err := c.GetValue(key2)
+	if err != nil {
+		return types.RedisValue{}, types.RedisValue{}, fmt.Errorf("error getting value for %s: %w", key2, err)
+	}
 	return val1, val2, nil
-}
-
-type valueFetchCmds struct {
-	strCmd    *redis.StringCmd
-	listCmd   *redis.StringSliceCmd
-	setCmd    *redis.StringSliceCmd
-	zsetCmd   *redis.ZSliceCmd
-	hashCmd   *redis.MapStringStringCmd
-	streamCmd *redis.XMessageSliceCmd
-	jsonCmd   *redis.Cmd
-}
-
-func queueValueFetch(pipe redis.Pipeliner, ctx context.Context, key, keyType string) valueFetchCmds {
-	var r valueFetchCmds
-	switch keyType {
-	case "string":
-		r.strCmd = pipe.Get(ctx, key)
-	case "list":
-		r.listCmd = pipe.LRange(ctx, key, 0, -1)
-	case "set":
-		r.setCmd = pipe.SMembers(ctx, key)
-	case "zset":
-		r.zsetCmd = pipe.ZRangeWithScores(ctx, key, 0, -1)
-	case "hash":
-		r.hashCmd = pipe.HGetAll(ctx, key)
-	case "stream":
-		r.streamCmd = pipe.XRange(ctx, key, "-", "+")
-	case "ReJSON-RL":
-		r.jsonCmd = pipe.Do(ctx, "JSON.GET", key, "$")
-	}
-	return r
-}
-
-func extractValue(keyType string, r valueFetchCmds) types.RedisValue {
-	var value types.RedisValue
-	value.Type = types.KeyType(keyType)
-
-	switch keyType {
-	case "string":
-		if r.strCmd != nil {
-			value.StringValue, _ = r.strCmd.Result()
-			if len(value.StringValue) >= 4 && value.StringValue[:4] == "HYLL" {
-				value.Type = types.KeyTypeHyperLogLog
-			} else if decoded, ok := decode.TryBinary([]byte(value.StringValue)); ok {
-				value.Type = types.KeyTypeProtobuf
-				value.DecodedValue = decoded.Text
-				value.DecodedFormat = decoded.Format
-				value.RawSize = decoded.RawSize
-				value.DecodedSize = decoded.DecodedSize
-			} else if isBinaryString(value.StringValue) {
-				value.Type = types.KeyTypeBitmap
-				value.BitPositions = extractBitPositions([]byte(value.StringValue), maxBitPositions)
-			}
-		}
-	case "list":
-		if r.listCmd != nil {
-			value.ListValue, _ = r.listCmd.Result()
-		}
-	case "set":
-		if r.setCmd != nil {
-			value.SetValue, _ = r.setCmd.Result()
-		}
-	case "zset":
-		if r.zsetCmd != nil {
-			vals, _ := r.zsetCmd.Result()
-			for _, z := range vals {
-				value.ZSetValue = append(value.ZSetValue, types.ZSetMember{
-					Member: z.Member.(string),
-					Score:  z.Score,
-				})
-			}
-		}
-	case "hash":
-		if r.hashCmd != nil {
-			value.HashValue, _ = r.hashCmd.Result()
-		}
-	case "stream":
-		if r.streamCmd != nil {
-			entries, _ := r.streamCmd.Result()
-			for _, entry := range entries {
-				value.StreamValue = append(value.StreamValue, types.StreamEntry{
-					ID:     entry.ID,
-					Fields: entry.Values,
-				})
-			}
-		}
-	case "ReJSON-RL":
-		if r.jsonCmd != nil {
-			value.JSONValue, _ = r.jsonCmd.Text()
-		}
-	}
-
-	return value
 }

--- a/internal/redis/io_test.go
+++ b/internal/redis/io_test.go
@@ -993,29 +993,6 @@ func TestImportKeys_ReJSONWithTTL(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// queueValueFetch / extractValue — direct call with ReJSON-RL keyType
-// ---------------------------------------------------------------------------
-
-func TestQueueValueFetch_ReJSON(t *testing.T) {
-	client, _ := setupTestClient(t)
-
-	pipe := client.pipeline()
-	cmds := queueValueFetch(pipe, client.ctx, "jsonkey", "ReJSON-RL")
-	_, _ = pipe.Exec(client.ctx)
-
-	if cmds.jsonCmd == nil {
-		t.Error("expected jsonCmd to be set for ReJSON-RL keyType")
-	}
-
-	// extractValue should walk the ReJSON-RL branch (Text() will return an
-	// error from miniredis but the branch is still exercised).
-	val := extractValue("ReJSON-RL", cmds)
-	if val.Type != "ReJSON-RL" {
-		t.Errorf("Type = %q, want ReJSON-RL", val.Type)
-	}
-}
-
 func TestCompareKeys_StringSubtypes(t *testing.T) {
 	client, mr := setupTestClient(t)
 
@@ -1068,28 +1045,11 @@ func indexOfStr(s, sub string) int {
 	return -1
 }
 
-func TestExtractValue_AllTypes(t *testing.T) {
-	// Empty fetch cmds — verifies the nil-check branches in each case arm.
-	for _, kt := range []string{"string", "list", "set", "zset", "hash", "stream", "ReJSON-RL"} {
-		val := extractValue(kt, valueFetchCmds{})
-		if string(val.Type) != kt {
-			t.Errorf("Type = %q, want %q", val.Type, kt)
-		}
-	}
-
-	// Default branch — unknown type just sets Type and returns.
-	val := extractValue("unknown", valueFetchCmds{})
-	if string(val.Type) != "unknown" {
-		t.Errorf("Type = %q, want unknown", val.Type)
-	}
-}
-
 // ---------------------------------------------------------------------------
-// CompareKeys — TYPE pipeline error path. Use the fake server to make TYPE
-// return an error so the pipeline Exec returns a non-nil, non-redis.Nil err.
+// CompareKeys — GetValue error paths (first and second key).
 // ---------------------------------------------------------------------------
 
-func TestCompareKeys_TypeExecError(t *testing.T) {
+func TestCompareKeys_FirstKeyError(t *testing.T) {
 	srv := newFakeRedisServer(t)
 	srv.setHandler(func(argv []string) string {
 		if argv[0] == "TYPE" {
@@ -1105,13 +1065,63 @@ func TestCompareKeys_TypeExecError(t *testing.T) {
 	t.Cleanup(func() { _ = c.Disconnect() })
 
 	if _, _, err := c.CompareKeys("a", "b"); err == nil {
-		t.Error("expected error from CompareKeys when TYPE pipeline errors")
+		t.Error("expected error from CompareKeys when first GetValue fails")
+	}
+}
+
+func TestCompareKeys_SecondKeyError(t *testing.T) {
+	srv := newFakeRedisServer(t)
+	srv.setHandler(func(argv []string) string {
+		switch argv[0] {
+		case "TYPE":
+			if len(argv) > 1 && argv[1] == "b" {
+				return "-ERR injected\r\n"
+			}
+			return "+string\r\n"
+		case "STRLEN":
+			return ":5\r\n"
+		case "GETRANGE":
+			return respBulkString("hello")
+		}
+		return ""
+	})
+	host, port := srv.addr()
+	c := NewClient()
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Disconnect() })
+
+	if _, _, err := c.CompareKeys("a", "b"); err == nil {
+		t.Error("expected error from CompareKeys when second GetValue fails")
+	}
+}
+
+func TestCompareKeys_TruncatesLargeValues(t *testing.T) {
+	client, mr := setupTestClient(t)
+	total := detailMaxItems + 25
+	for i := 0; i < total; i++ {
+		mr.RPush("cmpbig1", "x")
+		mr.RPush("cmpbig2", "y")
+	}
+
+	v1, v2, err := client.CompareKeys("cmpbig1", "cmpbig2")
+	if err != nil {
+		t.Fatalf("CompareKeys error: %v", err)
+	}
+	if len(v1.ListValue) != detailMaxItems || len(v2.ListValue) != detailMaxItems {
+		t.Errorf("list lengths = %d/%d, want %d/%d", len(v1.ListValue), len(v2.ListValue), detailMaxItems, detailMaxItems)
+	}
+	if !v1.Truncated || !v2.Truncated {
+		t.Error("expected both compare values Truncated = true")
+	}
+	if v1.TotalCount != int64(total) || v2.TotalCount != int64(total) {
+		t.Errorf("TotalCount = %d/%d, want %d/%d", v1.TotalCount, v2.TotalCount, total, total)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// CompareKeys — exercise non-string types so queueValueFetch and extractValue
-// take their list/set/zset/hash/stream branches.
+// CompareKeys — exercise non-string types via the shared GetValue path.
 // ---------------------------------------------------------------------------
 
 func TestCompareKeys_AllTypes(t *testing.T) {

--- a/internal/redis/operations.go
+++ b/internal/redis/operations.go
@@ -4,7 +4,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/davidbudnick/redis-tui/internal/decode"
 	"github.com/davidbudnick/redis-tui/internal/types"
 	"github.com/redis/go-redis/v9"
 )
@@ -14,120 +13,9 @@ import (
 // large bitmap could allocate millions of entries.
 const maxBitPositions = 1024
 
-// GetValue retrieves the value for a key
+// GetValue retrieves a bounded detail value for a key (never unbounded dumps).
 func (c *Client) GetValue(key string) (types.RedisValue, error) {
-	keyType, err := c.cmdable().Type(c.ctx, key).Result()
-	if err != nil {
-		return types.RedisValue{}, err
-	}
-
-	var value types.RedisValue
-	value.Type = types.KeyType(keyType)
-
-	switch keyType {
-	case "string":
-		val, err := c.cmdable().Get(c.ctx, key).Result()
-		if err != nil {
-			return value, err
-		}
-		value.StringValue = val
-
-		// Detect HyperLogLog: raw value starts with "HYLL" magic bytes
-		if len(val) >= 4 && val[:4] == "HYLL" {
-			value.Type = types.KeyTypeHyperLogLog
-			count, err := c.cmdable().PFCount(c.ctx, key).Result()
-			if err == nil {
-				value.HLLCount = count
-			}
-		} else if decoded, ok := decode.TryBinary([]byte(val)); ok {
-			value.Type = types.KeyTypeProtobuf
-			value.DecodedValue = decoded.Text
-			value.DecodedFormat = decoded.Format
-			value.RawSize = decoded.RawSize
-			value.DecodedSize = decoded.DecodedSize
-		} else if isBinaryString(val) {
-			applyBinaryStringValue(&value, val, c, key)
-		}
-
-	case "list":
-		vals, err := c.cmdable().LRange(c.ctx, key, 0, -1).Result()
-		if err != nil {
-			return value, err
-		}
-		value.ListValue = vals
-
-	case "set":
-		vals, err := c.cmdable().SMembers(c.ctx, key).Result()
-		if err != nil {
-			return value, err
-		}
-		value.SetValue = vals
-
-	case "zset":
-		vals, err := c.cmdable().ZRangeWithScores(c.ctx, key, 0, -1).Result()
-		if err != nil {
-			return value, err
-		}
-		for _, z := range vals {
-			value.ZSetValue = append(value.ZSetValue, types.ZSetMember{
-				Member: z.Member.(string),
-				Score:  z.Score,
-			})
-		}
-
-		// Detect Geo: check if scores look like 52-bit geohash integers
-		if len(value.ZSetValue) > 0 && looksLikeGeoScores(value.ZSetValue) {
-			members := make([]string, len(value.ZSetValue))
-			for i, m := range value.ZSetValue {
-				members[i] = m.Member
-			}
-			positions, err := c.cmdable().GeoPos(c.ctx, key, members...).Result()
-			if err == nil {
-				var geoMembers []types.GeoMember
-				for i, pos := range positions {
-					if pos != nil {
-						geoMembers = append(geoMembers, types.GeoMember{
-							Name:      members[i],
-							Longitude: pos.Longitude,
-							Latitude:  pos.Latitude,
-						})
-					}
-				}
-				if len(geoMembers) > 0 {
-					value.Type = types.KeyTypeGeo
-					value.GeoValue = geoMembers
-				}
-			}
-		}
-
-	case "hash":
-		vals, err := c.cmdable().HGetAll(c.ctx, key).Result()
-		if err != nil {
-			return value, err
-		}
-		value.HashValue = vals
-
-	case "stream":
-		entries, err := c.cmdable().XRange(c.ctx, key, "-", "+").Result()
-		if err != nil {
-			return value, err
-		}
-		for _, entry := range entries {
-			value.StreamValue = append(value.StreamValue, types.StreamEntry{
-				ID:     entry.ID,
-				Fields: entry.Values,
-			})
-		}
-
-	case "ReJSON-RL":
-		val, err := c.do("JSON.GET", key, "$").Text()
-		if err != nil {
-			return value, err
-		}
-		value.JSONValue = val
-	}
-
-	return value, nil
+	return c.getValueBounded(key, detailMaxItems, detailMaxStringBytes, false)
 }
 
 // looksLikeGeoScores returns true if all sorted set scores look like 52-bit
@@ -153,16 +41,6 @@ func isBinaryString(s string) bool {
 		return false
 	}
 	return !utf8.ValidString(s)
-}
-
-// applyBinaryStringValue classifies remaining binary Redis strings as bitmaps.
-func applyBinaryStringValue(value *types.RedisValue, val string, c *Client, key string) {
-	value.Type = types.KeyTypeBitmap
-	count, err := c.cmdable().BitCount(c.ctx, key, &redis.BitCount{Start: 0, End: -1}).Result()
-	if err == nil {
-		value.BitCount = count
-	}
-	value.BitPositions = extractBitPositions([]byte(val), maxBitPositions)
 }
 
 // extractBitPositions returns up to max set bit offsets from raw bytes.

--- a/internal/redis/operations_test.go
+++ b/internal/redis/operations_test.go
@@ -761,13 +761,15 @@ func TestBatchSetTTL_Persist(t *testing.T) {
 
 func TestGetValue_HyperLogLog_PFCountSuccess(t *testing.T) {
 	srv := newFakeRedisServer(t)
+	hll := "HYLL" + string(make([]byte, 12))
 	srv.setHandler(func(argv []string) string {
 		switch argv[0] {
 		case "TYPE":
 			return "+string\r\n"
-		case "GET":
-			// Return HYLL-prefixed bulk string so HLL detection triggers.
-			return respBulkString("HYLL" + string(make([]byte, 12)))
+		case "STRLEN":
+			return fmt.Sprintf(":%d\r\n", len(hll))
+		case "GETRANGE":
+			return respBulkString(hll)
 		case "PFCOUNT":
 			return ":7\r\n"
 		}
@@ -818,17 +820,19 @@ func TestGetValue_TypeError(t *testing.T) {
 }
 
 // gvFakeClient connects a real Client to a fakeRedisServer that responds to
-// TYPE with the requested key type and to the matching value command with an
-// error. This drives the error-return branches inside GetValue.
-func gvFakeClient(t *testing.T, keyType string, valueCmd string) *Client {
+// TYPE with the requested key type, optional prefetch successes, then fails valueCmd.
+func gvFakeClient(t *testing.T, keyType string, valueCmd string, prefetch map[string]string) *Client {
 	t.Helper()
 	srv := newFakeRedisServer(t)
 	srv.setHandler(func(argv []string) string {
-		switch argv[0] {
-		case "TYPE":
-			return "+" + keyType + "\r\n"
-		case valueCmd:
+		if argv[0] == valueCmd {
 			return "-ERR injected\r\n"
+		}
+		if argv[0] == "TYPE" {
+			return "+" + keyType + "\r\n"
+		}
+		if resp, ok := prefetch[argv[0]]; ok {
+			return resp
 		}
 		return ""
 	})
@@ -842,42 +846,84 @@ func gvFakeClient(t *testing.T, keyType string, valueCmd string) *Client {
 }
 
 func TestGetValue_StringError(t *testing.T) {
-	c := gvFakeClient(t, "string", "GET")
+	c := gvFakeClient(t, "string", "STRLEN", nil)
 	if _, err := c.GetValue("k"); err == nil {
-		t.Error("expected error from GetValue on string GET error")
+		t.Error("expected error from GetValue on string STRLEN error")
+	}
+}
+
+func TestGetValue_StringGetRangeError(t *testing.T) {
+	c := gvFakeClient(t, "string", "GETRANGE", map[string]string{"STRLEN": ":5\r\n"})
+	if _, err := c.GetValue("k"); err == nil {
+		t.Error("expected error from GetValue on string GETRANGE error")
 	}
 }
 
 func TestGetValue_ListError(t *testing.T) {
-	c := gvFakeClient(t, "list", "LRANGE")
+	c := gvFakeClient(t, "list", "LLEN", nil)
+	if _, err := c.GetValue("k"); err == nil {
+		t.Error("expected error from GetValue on list LLEN error")
+	}
+}
+
+func TestGetValue_ListLRangeError(t *testing.T) {
+	c := gvFakeClient(t, "list", "LRANGE", map[string]string{"LLEN": ":5\r\n"})
 	if _, err := c.GetValue("k"); err == nil {
 		t.Error("expected error from GetValue on list LRANGE error")
 	}
 }
 
 func TestGetValue_SetError(t *testing.T) {
-	c := gvFakeClient(t, "set", "SMEMBERS")
+	c := gvFakeClient(t, "set", "SCARD", nil)
 	if _, err := c.GetValue("k"); err == nil {
-		t.Error("expected error from GetValue on set SMEMBERS error")
+		t.Error("expected error from GetValue on set SCARD error")
+	}
+}
+
+func TestGetValue_SetScanError(t *testing.T) {
+	c := gvFakeClient(t, "set", "SSCAN", map[string]string{"SCARD": ":5\r\n"})
+	if _, err := c.GetValue("k"); err == nil {
+		t.Error("expected error from GetValue on set SSCAN error")
 	}
 }
 
 func TestGetValue_ZSetError(t *testing.T) {
-	c := gvFakeClient(t, "zset", "ZRANGE")
+	c := gvFakeClient(t, "zset", "ZCARD", nil)
+	if _, err := c.GetValue("k"); err == nil {
+		t.Error("expected error from GetValue on zset ZCARD error")
+	}
+}
+
+func TestGetValue_ZSetRangeError(t *testing.T) {
+	c := gvFakeClient(t, "zset", "ZRANGE", map[string]string{"ZCARD": ":5\r\n"})
 	if _, err := c.GetValue("k"); err == nil {
 		t.Error("expected error from GetValue on zset ZRANGE error")
 	}
 }
 
 func TestGetValue_HashError(t *testing.T) {
-	c := gvFakeClient(t, "hash", "HGETALL")
+	c := gvFakeClient(t, "hash", "HLEN", nil)
 	if _, err := c.GetValue("k"); err == nil {
-		t.Error("expected error from GetValue on hash HGETALL error")
+		t.Error("expected error from GetValue on hash HLEN error")
+	}
+}
+
+func TestGetValue_HashScanError(t *testing.T) {
+	c := gvFakeClient(t, "hash", "HSCAN", map[string]string{"HLEN": ":5\r\n"})
+	if _, err := c.GetValue("k"); err == nil {
+		t.Error("expected error from GetValue on hash HSCAN error")
 	}
 }
 
 func TestGetValue_StreamError(t *testing.T) {
-	c := gvFakeClient(t, "stream", "XRANGE")
+	c := gvFakeClient(t, "stream", "XLEN", nil)
+	if _, err := c.GetValue("k"); err == nil {
+		t.Error("expected error from GetValue on stream XLEN error")
+	}
+}
+
+func TestGetValue_StreamRangeError(t *testing.T) {
+	c := gvFakeClient(t, "stream", "XRANGE", map[string]string{"XLEN": ":5\r\n"})
 	if _, err := c.GetValue("k"); err == nil {
 		t.Error("expected error from GetValue on stream XRANGE error")
 	}
@@ -1180,6 +1226,157 @@ func TestGetValue_Protobuf_S2(t *testing.T) {
 	}
 }
 
+func TestGetValue_TruncatesLargeValues(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		total := detailMaxStringBytes + 2048
+		mr.Set("bigstr", strings.Repeat("a", total))
+
+		v, err := client.GetValue("bigstr")
+		if err != nil {
+			t.Fatalf("GetValue error: %v", err)
+		}
+		if len(v.StringValue) != detailMaxStringBytes {
+			t.Errorf("StringValue length = %d, want %d", len(v.StringValue), detailMaxStringBytes)
+		}
+		if !v.Truncated {
+			t.Error("expected Truncated = true")
+		}
+		if v.TotalCount != int64(total) {
+			t.Errorf("TotalCount = %d, want %d", v.TotalCount, total)
+		}
+	})
+
+	t.Run("string small not truncated", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		mr.Set("small", "hello")
+		v, err := client.GetValue("small")
+		if err != nil {
+			t.Fatalf("GetValue error: %v", err)
+		}
+		if v.Truncated {
+			t.Error("expected Truncated = false")
+		}
+		if v.StringValue != "hello" {
+			t.Errorf("StringValue = %q, want hello", v.StringValue)
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		total := detailMaxItems + 50
+		for i := 0; i < total; i++ {
+			mr.RPush("biglist", "item")
+		}
+		v, err := client.GetValue("biglist")
+		if err != nil {
+			t.Fatalf("GetValue error: %v", err)
+		}
+		if len(v.ListValue) != detailMaxItems {
+			t.Errorf("ListValue length = %d, want %d", len(v.ListValue), detailMaxItems)
+		}
+		if !v.Truncated || v.TotalCount != int64(total) {
+			t.Errorf("Truncated/TotalCount = %v/%d, want true/%d", v.Truncated, v.TotalCount, total)
+		}
+	})
+
+	t.Run("set", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		total := detailMaxItems + 50
+		for i := 0; i < total; i++ {
+			mr.SAdd("bigset", fmt.Sprintf("m:%06d", i))
+		}
+		v, err := client.GetValue("bigset")
+		if err != nil {
+			t.Fatalf("GetValue error: %v", err)
+		}
+		if len(v.SetValue) != detailMaxItems {
+			t.Errorf("SetValue length = %d, want %d", len(v.SetValue), detailMaxItems)
+		}
+		if !v.Truncated || v.TotalCount != int64(total) {
+			t.Errorf("Truncated/TotalCount = %v/%d, want true/%d", v.Truncated, v.TotalCount, total)
+		}
+	})
+
+	t.Run("zset", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		total := detailMaxItems + 50
+		for i := 0; i < total; i++ {
+			mr.ZAdd("bigz", float64(i), fmt.Sprintf("m:%06d", i))
+		}
+		v, err := client.GetValue("bigz")
+		if err != nil {
+			t.Fatalf("GetValue error: %v", err)
+		}
+		if len(v.ZSetValue) != detailMaxItems {
+			t.Errorf("ZSetValue length = %d, want %d", len(v.ZSetValue), detailMaxItems)
+		}
+		if !v.Truncated || v.TotalCount != int64(total) {
+			t.Errorf("Truncated/TotalCount = %v/%d, want true/%d", v.Truncated, v.TotalCount, total)
+		}
+	})
+
+	t.Run("hash", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		total := detailMaxItems + 50
+		for i := 0; i < total; i++ {
+			mr.HSet("bighash", fmt.Sprintf("f:%06d", i), "v")
+		}
+		v, err := client.GetValue("bighash")
+		if err != nil {
+			t.Fatalf("GetValue error: %v", err)
+		}
+		if len(v.HashValue) != detailMaxItems {
+			t.Errorf("HashValue length = %d, want %d", len(v.HashValue), detailMaxItems)
+		}
+		if !v.Truncated || v.TotalCount != int64(total) {
+			t.Errorf("Truncated/TotalCount = %v/%d, want true/%d", v.Truncated, v.TotalCount, total)
+		}
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		client, _ := setupTestClient(t)
+		total := detailMaxItems + 50
+		for i := 0; i < total; i++ {
+			if _, err := client.XAdd("bigstream", map[string]any{"k": "v"}); err != nil {
+				t.Fatalf("XAdd error: %v", err)
+			}
+		}
+		v, err := client.GetValue("bigstream")
+		if err != nil {
+			t.Fatalf("GetValue error: %v", err)
+		}
+		if len(v.StreamValue) != detailMaxItems {
+			t.Errorf("StreamValue length = %d, want %d", len(v.StreamValue), detailMaxItems)
+		}
+		if !v.Truncated || v.TotalCount != int64(total) {
+			t.Errorf("Truncated/TotalCount = %v/%d, want true/%d", v.Truncated, v.TotalCount, total)
+		}
+	})
+
+	t.Run("truncated bitmap still classified", func(t *testing.T) {
+		client, mr := setupTestClient(t)
+		bin := make([]byte, detailMaxStringBytes+512)
+		for i := range bin {
+			bin[i] = 0xff
+		}
+		mr.Set("bigbm", string(bin))
+
+		v, err := client.GetValue("bigbm")
+		if err != nil {
+			t.Fatalf("GetValue error: %v", err)
+		}
+		if v.Type != types.KeyTypeBitmap {
+			t.Errorf("Type = %q, want bitmap", v.Type)
+		}
+		if !v.Truncated {
+			t.Error("expected Truncated = true")
+		}
+		if len(v.BitPositions) != maxBitPositions {
+			t.Errorf("BitPositions length = %d, want %d", len(v.BitPositions), maxBitPositions)
+		}
+	})
+}
 
 func TestExtractBitPositions_Caps(t *testing.T) {
 	// 32 bytes all 0xff → 256 set bits; cap at 10.

--- a/internal/redis/preview.go
+++ b/internal/redis/preview.go
@@ -8,12 +8,10 @@ import (
 )
 
 const (
-	// previewMaxItems caps how many collection entries are fetched for the
-	// keys-list preview panel, which only ever displays a screenful.
-	previewMaxItems = 100
-	// previewMaxStringBytes caps how many bytes of a string value are fetched
-	// for the preview panel.
+	previewMaxItems       = 100
 	previewMaxStringBytes = 64 * 1024
+	detailMaxItems        = 1000
+	detailMaxStringBytes  = 1024 * 1024
 )
 
 // GetValuePreview retrieves a bounded preview of a key's value. Unlike
@@ -23,6 +21,21 @@ const (
 // value was cut off, Truncated is set and TotalCount holds the full
 // length/cardinality.
 func (c *Client) GetValuePreview(key string) (types.RedisValue, error) {
+	return c.getValueBounded(key, previewMaxItems, previewMaxStringBytes, true)
+}
+
+// markTruncated sets the Truncated/TotalCount fields when fewer entries were
+// fetched than exist.
+func markTruncated(value *types.RedisValue, total int64, fetched int) {
+	if total > int64(fetched) {
+		value.Truncated = true
+		value.TotalCount = total
+	}
+}
+
+// getValueBounded loads a key with collection/string caps. When deferTruncatedBinary
+// is true, truncated non-protobuf binary stays typed as string (preview path).
+func (c *Client) getValueBounded(key string, maxItems int, maxStringBytes int64, deferTruncatedBinary bool) (types.RedisValue, error) {
 	keyType, err := c.cmdable().Type(c.ctx, key).Result()
 	if err != nil {
 		return types.RedisValue{}, err
@@ -33,80 +46,34 @@ func (c *Client) GetValuePreview(key string) (types.RedisValue, error) {
 
 	switch keyType {
 	case "string":
-		if err := c.previewString(key, &value); err != nil {
+		if err := c.fetchString(key, &value, maxStringBytes, deferTruncatedBinary); err != nil {
 			return value, err
 		}
 
 	case "list":
-		total, err := c.cmdable().LLen(c.ctx, key).Result()
-		if err != nil {
+		if err := c.fetchList(key, &value, maxItems); err != nil {
 			return value, err
 		}
-		vals, err := c.cmdable().LRange(c.ctx, key, 0, previewMaxItems-1).Result()
-		if err != nil {
-			return value, err
-		}
-		value.ListValue = vals
-		markTruncated(&value, total, len(vals))
 
 	case "set":
-		total, err := c.cmdable().SCard(c.ctx, key).Result()
-		if err != nil {
+		if err := c.fetchSet(key, &value, maxItems); err != nil {
 			return value, err
 		}
-		members, err := c.scanSetPreview(key)
-		if err != nil {
-			return value, err
-		}
-		value.SetValue = members
-		markTruncated(&value, total, len(members))
 
 	case "zset":
-		total, err := c.cmdable().ZCard(c.ctx, key).Result()
-		if err != nil {
+		if err := c.fetchZSet(key, &value, maxItems); err != nil {
 			return value, err
 		}
-		vals, err := c.cmdable().ZRangeWithScores(c.ctx, key, 0, previewMaxItems-1).Result()
-		if err != nil {
-			return value, err
-		}
-		for _, z := range vals {
-			value.ZSetValue = append(value.ZSetValue, types.ZSetMember{
-				Member: z.Member.(string),
-				Score:  z.Score,
-			})
-		}
-		markTruncated(&value, total, len(value.ZSetValue))
-		c.previewGeoDetect(key, &value)
 
 	case "hash":
-		total, err := c.cmdable().HLen(c.ctx, key).Result()
-		if err != nil {
+		if err := c.fetchHash(key, &value, maxItems); err != nil {
 			return value, err
 		}
-		fields, err := c.scanHashPreview(key)
-		if err != nil {
-			return value, err
-		}
-		value.HashValue = fields
-		markTruncated(&value, total, len(fields))
 
 	case "stream":
-		total, err := c.cmdable().XLen(c.ctx, key).Result()
-		if err != nil {
+		if err := c.fetchStream(key, &value, maxItems); err != nil {
 			return value, err
 		}
-		entries, err := c.cmdable().XRangeN(c.ctx, key, "-", "+", previewMaxItems).Result()
-		if err != nil {
-			return value, err
-		}
-		for _, entry := range entries {
-			value.StreamValue = append(value.StreamValue, types.StreamEntry{
-				ID:     entry.ID,
-				Fields: entry.Values,
-			})
-		}
-		markTruncated(&value, total, len(value.StreamValue))
 
 	case "ReJSON-RL":
 		val, err := c.do("JSON.GET", key, "$").Text()
@@ -119,23 +86,13 @@ func (c *Client) GetValuePreview(key string) (types.RedisValue, error) {
 	return value, nil
 }
 
-// markTruncated sets the Truncated/TotalCount fields when fewer entries were
-// fetched than exist.
-func markTruncated(value *types.RedisValue, total int64, fetched int) {
-	if total > int64(fetched) {
-		value.Truncated = true
-		value.TotalCount = total
-	}
-}
-
-// previewString fills in a bounded string preview, including HLL, protobuf, and
-// bitmap subtype detection on the fetched bytes.
-func (c *Client) previewString(key string, value *types.RedisValue) error {
+// fetchString fills a bounded string value, including HLL/protobuf/bitmap detection.
+func (c *Client) fetchString(key string, value *types.RedisValue, maxBytes int64, deferTruncatedBinary bool) error {
 	total, err := c.cmdable().StrLen(c.ctx, key).Result()
 	if err != nil {
 		return err
 	}
-	val, err := c.cmdable().GetRange(c.ctx, key, 0, previewMaxStringBytes-1).Result()
+	val, err := c.cmdable().GetRange(c.ctx, key, 0, maxBytes-1).Result()
 	if err != nil {
 		return err
 	}
@@ -150,8 +107,6 @@ func (c *Client) previewString(key string, value *types.RedisValue) error {
 		return nil
 	}
 
-	// Prefer protobuf (incl. s2-compressed) over bitmap: binary probes that are
-	// really compressed menus must not be labeled as bitmaps in the list UI.
 	if decoded, ok := decode.TryBinary([]byte(val)); ok {
 		value.Type = types.KeyTypeProtobuf
 		value.DecodedValue = decoded.Text
@@ -164,9 +119,7 @@ func (c *Client) previewString(key string, value *types.RedisValue) error {
 	binary := isBinaryString(val)
 	if value.Truncated {
 		binary = isBinaryPrefix(val)
-		// Incomplete binary blob may still be compressed protobuf that only
-		// decodes with the full payload — leave type as string until GetValue.
-		if binary {
+		if binary && deferTruncatedBinary {
 			return nil
 		}
 	}
@@ -180,33 +133,137 @@ func (c *Client) previewString(key string, value *types.RedisValue) error {
 	return nil
 }
 
-// scanSetPreview collects roughly previewMaxItems set members from a single
-// SSCAN iteration. COUNT is a hint, so slightly more or fewer entries may be
-// returned — the preview panel only displays a screenful either way.
-func (c *Client) scanSetPreview(key string) ([]string, error) {
-	members, _, err := c.cmdable().SScan(c.ctx, key, 0, "", previewMaxItems).Result()
-	return members, err
+// fetchList loads up to maxItems list elements.
+func (c *Client) fetchList(key string, value *types.RedisValue, maxItems int) error {
+	total, err := c.cmdable().LLen(c.ctx, key).Result()
+	if err != nil {
+		return err
+	}
+	vals, err := c.cmdable().LRange(c.ctx, key, 0, int64(maxItems)-1).Result()
+	if err != nil {
+		return err
+	}
+	value.ListValue = vals
+	markTruncated(value, total, len(vals))
+	return nil
 }
 
-// scanHashPreview collects roughly previewMaxItems hash fields from a single
-// HSCAN iteration (returned as flattened field/value pairs). COUNT is only a
-// hint, so servers may return more pairs than asked; inserts are capped so the
-// preview never materializes an unbounded map.
-func (c *Client) scanHashPreview(key string) (map[string]string, error) {
-	batch, _, err := c.cmdable().HScan(c.ctx, key, 0, "", previewMaxItems).Result()
+// fetchSet loads up to maxItems set members via SSCAN.
+func (c *Client) fetchSet(key string, value *types.RedisValue, maxItems int) error {
+	total, err := c.cmdable().SCard(c.ctx, key).Result()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	fields := make(map[string]string, previewMaxItems)
-	for i := 0; i+1 < len(batch) && len(fields) < previewMaxItems; i += 2 {
-		fields[batch[i]] = batch[i+1]
+	members, err := c.scanSetMembers(key, maxItems)
+	if err != nil {
+		return err
+	}
+	value.SetValue = members
+	markTruncated(value, total, len(members))
+	return nil
+}
+
+// fetchZSet loads up to maxItems sorted-set members and detects geo keys.
+func (c *Client) fetchZSet(key string, value *types.RedisValue, maxItems int) error {
+	total, err := c.cmdable().ZCard(c.ctx, key).Result()
+	if err != nil {
+		return err
+	}
+	vals, err := c.cmdable().ZRangeWithScores(c.ctx, key, 0, int64(maxItems)-1).Result()
+	if err != nil {
+		return err
+	}
+	for _, z := range vals {
+		value.ZSetValue = append(value.ZSetValue, types.ZSetMember{
+			Member: z.Member.(string),
+			Score:  z.Score,
+		})
+	}
+	markTruncated(value, total, len(value.ZSetValue))
+	c.detectGeo(key, value)
+	return nil
+}
+
+// fetchHash loads up to maxItems hash fields via HSCAN.
+func (c *Client) fetchHash(key string, value *types.RedisValue, maxItems int) error {
+	total, err := c.cmdable().HLen(c.ctx, key).Result()
+	if err != nil {
+		return err
+	}
+	fields, err := c.scanHashFields(key, maxItems)
+	if err != nil {
+		return err
+	}
+	value.HashValue = fields
+	markTruncated(value, total, len(fields))
+	return nil
+}
+
+// fetchStream loads up to maxItems stream entries.
+func (c *Client) fetchStream(key string, value *types.RedisValue, maxItems int) error {
+	total, err := c.cmdable().XLen(c.ctx, key).Result()
+	if err != nil {
+		return err
+	}
+	entries, err := c.cmdable().XRangeN(c.ctx, key, "-", "+", int64(maxItems)).Result()
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		value.StreamValue = append(value.StreamValue, types.StreamEntry{
+			ID:     entry.ID,
+			Fields: entry.Values,
+		})
+	}
+	markTruncated(value, total, len(value.StreamValue))
+	return nil
+}
+
+// scanSetMembers collects up to maxItems set members via SSCAN.
+func (c *Client) scanSetMembers(key string, maxItems int) ([]string, error) {
+	members := make([]string, 0, maxItems)
+	var cursor uint64
+	for len(members) < maxItems {
+		batch, next, err := c.cmdable().SScan(c.ctx, key, cursor, "", int64(maxItems)).Result()
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range batch {
+			members = append(members, m)
+			if len(members) >= maxItems {
+				break
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return members, nil
+}
+
+// scanHashFields collects up to maxItems hash fields via HSCAN.
+func (c *Client) scanHashFields(key string, maxItems int) (map[string]string, error) {
+	fields := make(map[string]string, maxItems)
+	var cursor uint64
+	for len(fields) < maxItems {
+		batch, next, err := c.cmdable().HScan(c.ctx, key, cursor, "", int64(maxItems)).Result()
+		if err != nil {
+			return nil, err
+		}
+		for i := 0; i+1 < len(batch) && len(fields) < maxItems; i += 2 {
+			fields[batch[i]] = batch[i+1]
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
 	}
 	return fields, nil
 }
 
-// previewGeoDetect flips a zset preview to Geo when its scores look like
-// geohash integers, resolving coordinates for the previewed members.
-func (c *Client) previewGeoDetect(key string, value *types.RedisValue) {
+// detectGeo flips a zset to Geo when scores look like geohash integers.
+func (c *Client) detectGeo(key string, value *types.RedisValue) {
 	if len(value.ZSetValue) == 0 || !looksLikeGeoScores(value.ZSetValue) {
 		return
 	}

--- a/internal/ui/view_keys_detail.go
+++ b/internal/ui/view_keys_detail.go
@@ -251,7 +251,15 @@ func buildDetailValueContent(value types.RedisValue) string {
 			}
 		}
 	}
-	return strings.TrimSpace(vc.String())
+	body := strings.TrimSpace(vc.String())
+	if value.Truncated {
+		marker := fmt.Sprintf("(truncated — %d total)", value.TotalCount)
+		if body == "" {
+			return marker
+		}
+		return body + "\n" + marker
+	}
+	return body
 }
 
 // formatProtobufValue renders decoded protobuf metadata and text body.

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -682,6 +682,30 @@ func TestPreviewFormattedAndTruncated(t *testing.T) {
 	}
 }
 
+func TestBuildDetailValueContent_Truncated(t *testing.T) {
+	out := buildDetailValueContent(types.RedisValue{
+		Type:       types.KeyTypeList,
+		ListValue:  []string{"a", "b"},
+		Truncated:  true,
+		TotalCount: 1500,
+	})
+	if !strings.Contains(out, "truncated") || !strings.Contains(out, "1500") {
+		t.Errorf("expected truncated marker, got %q", out)
+	}
+	if !strings.Contains(out, "a") {
+		t.Errorf("expected list body, got %q", out)
+	}
+
+	empty := buildDetailValueContent(types.RedisValue{
+		Type:       types.KeyTypeString,
+		Truncated:  true,
+		TotalCount: 42,
+	})
+	if !strings.Contains(empty, "truncated") || !strings.Contains(empty, "42") {
+		t.Errorf("expected truncated-only body, got %q", empty)
+	}
+}
+
 // BenchmarkViewKeyDetailLargeJSON measures one cached detail render frame.
 func BenchmarkViewKeyDetailLargeJSON(b *testing.B) {
 	var sb strings.Builder


### PR DESCRIPTION
## Summary
- Cap GetValue collection/string materialization so open-key cannot pull unbounded Redis data
- Bound CompareKeys the same way (shared limits / shared path)
- Surface Truncated/TotalCount on detail when cut off

## Test plan
- [x] go test -race ./internal/redis/...
- [ ] Manual: open a huge list key — detail shows truncated marker, stays responsive
- [ ] Manual: compare two large keys — completes quickly