### PR TITLE
perf: bound fuzzy and value search

### DIFF
--- a/internal/redis/enumeration.go
+++ b/internal/redis/enumeration.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"container/heap"
 	"fmt"
 	"regexp"
 	"sort"
@@ -112,6 +113,14 @@ const (
 	// classification when a short probe looks binary but is not yet classifiable
 	// (e.g. s2-compressed protobuf needs the complete blob to decode).
 	subtypeFullFetchMax int64 = 512 * 1024
+	// defaultSearchMaxKeys is used when callers pass maxKeys <= 0.
+	defaultSearchMaxKeys = 100
+	// searchMaxStringBytes caps string bytes inspected during value search
+	// (GETRANGE prefix). Matches outside this window may be missed.
+	searchMaxStringBytes int64 = previewMaxStringBytes
+	// searchMaxItems caps collection entries inspected during value search.
+	// Matches beyond this prefix window may be missed.
+	searchMaxItems = previewMaxItems
 )
 
 // ScanKeysWithRegex scans keys using regex pattern with early termination.
@@ -172,53 +181,46 @@ func (c *Client) ScanKeysWithRegex(regexPattern string, maxKeys int) ([]types.Re
 }
 
 // FuzzySearchKeys performs fuzzy matching on key names.
-// Scans incrementally to avoid holding the full keyspace in memory.
+// Scans the full keyspace for correct global top-N, keeping only O(maxKeys) scored candidates.
 func (c *Client) FuzzySearchKeys(searchTerm string, maxKeys int) ([]types.RedisKey, error) {
+	if maxKeys <= 0 {
+		maxKeys = defaultSearchMaxKeys
+	}
 	searchLower := strings.ToLower(searchTerm)
 
-	type scoredKey struct {
-		key   string
-		score int
-	}
-	var scoredKeys []scoredKey
-
+	top := make(scoreMinHeap, 0, maxKeys)
 	err := c.scanEach("*", scanBatchDefault, func(keys []string) bool {
 		for _, key := range keys {
-			keyLower := strings.ToLower(key)
-			score := fuzzyScore(keyLower, searchLower)
+			score := fuzzyScore(strings.ToLower(key), searchLower)
 			if score > 0 {
-				scoredKeys = append(scoredKeys, scoredKey{key: key, score: score})
+				top.consider(scoredKey{key: key, score: score}, maxKeys)
 			}
 		}
-		return true // must scan all keys for global top-N
+		return true
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// Sort by score descending
-	sort.Slice(scoredKeys, func(i, j int) bool {
-		return scoredKeys[i].score > scoredKeys[j].score
-	})
-
-	// Limit to maxKeys
-	limit := min(maxKeys, len(scoredKeys))
-	scoredKeys = scoredKeys[:limit]
-
-	if len(scoredKeys) == 0 {
+	if top.Len() == 0 {
 		return []types.RedisKey{}, nil
 	}
 
-	// Use pipeline to batch Type and TTL calls for top results only
+	scoredKeys := make([]scoredKey, top.Len())
+	for i := len(scoredKeys) - 1; i >= 0; i-- {
+		scoredKeys[i] = heap.Pop(&top).(scoredKey)
+	}
+	sort.SliceStable(scoredKeys, func(i, j int) bool {
+		return scoredKeys[i].score > scoredKeys[j].score
+	})
+
 	pipe := c.pipeline()
 	typeCmds := make([]*redis.StatusCmd, len(scoredKeys))
 	ttlCmds := make([]*redis.DurationCmd, len(scoredKeys))
-
 	for i, sk := range scoredKeys {
 		typeCmds[i] = pipe.Type(c.ctx, sk.key)
 		ttlCmds[i] = pipe.TTL(c.ctx, sk.key)
 	}
-
 	_, _ = pipe.Exec(c.ctx)
 
 	result := make([]types.RedisKey, len(scoredKeys))
@@ -231,8 +233,42 @@ func (c *Client) FuzzySearchKeys(searchTerm string, maxKeys int) ([]types.RedisK
 			TTL:  ttl,
 		}
 	}
-
 	return result, nil
+}
+
+type scoredKey struct {
+	key   string
+	score int
+}
+
+type scoreMinHeap []scoredKey
+
+func (h scoreMinHeap) Len() int           { return len(h) }
+func (h scoreMinHeap) Less(i, j int) bool { return h[i].score < h[j].score }
+func (h scoreMinHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *scoreMinHeap) Push(x any) { *h = append(*h, x.(scoredKey)) }
+
+func (h *scoreMinHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
+func (h *scoreMinHeap) consider(sk scoredKey, maxKeys int) {
+	if maxKeys <= 0 {
+		return
+	}
+	if h.Len() < maxKeys {
+		heap.Push(h, sk)
+		return
+	}
+	if sk.score > (*h)[0].score {
+		(*h)[0] = sk
+		heap.Fix(h, 0)
+	}
 }
 
 func fuzzyScore(str, pattern string) int {
@@ -260,11 +296,14 @@ func fuzzyScore(str, pattern string) int {
 }
 
 // SearchByValue searches for keys containing a value.
-// Uses 2 pipelines per chunk (TYPE + values) and defers TTL to a single final pipeline.
+// Streams SCAN batches, bounds value fetches to a prefix window, and stops at maxKeys.
+// Matches outside the inspected prefix (string/collection window) may be missed.
 func (c *Client) SearchByValue(pattern string, valueSearch string, maxKeys int) ([]types.RedisKey, error) {
-	allKeys, err := c.scanAll(pattern, scanBatchDefault)
-	if err != nil {
-		return nil, err
+	if maxKeys <= 0 {
+		maxKeys = defaultSearchMaxKeys
+	}
+	if pattern == "" {
+		pattern = "*"
 	}
 
 	type match struct {
@@ -273,13 +312,7 @@ func (c *Client) SearchByValue(pattern string, valueSearch string, maxKeys int) 
 	}
 	matches := make([]match, 0, maxKeys)
 
-	// Process in chunks to keep pipeline sizes reasonable
-	chunkSize := int(scanBatchDefault)
-	for i := 0; i < len(allKeys) && len(matches) < maxKeys; i += chunkSize {
-		end := min(i+chunkSize, len(allKeys))
-		keys := allKeys[i:end]
-
-		// Pipeline 1: get types for all keys
+	err := c.scanEach(pattern, scanBatchDefault, func(keys []string) bool {
 		typePipe := c.pipeline()
 		typeCmds := make([]*redis.StatusCmd, len(keys))
 		for j, key := range keys {
@@ -292,15 +325,14 @@ func (c *Client) SearchByValue(pattern string, valueSearch string, maxKeys int) 
 			keyTypes[j], _ = typeCmds[j].Result()
 		}
 
-		// Pipeline 2: get values based on type
 		valuePipe := c.pipeline()
 		type valueCmd struct {
 			idx     int
 			keyType string
 			strCmd  *redis.StringCmd
-			hashCmd *redis.MapStringStringCmd
+			hashCmd *redis.ScanCmd
 			listCmd *redis.StringSliceCmd
-			setCmd  *redis.StringSliceCmd
+			setCmd  *redis.ScanCmd
 			jsonCmd *redis.Cmd
 		}
 		valueCmds := make([]valueCmd, 0, len(keys))
@@ -310,13 +342,13 @@ func (c *Client) SearchByValue(pattern string, valueSearch string, maxKeys int) 
 			vc := valueCmd{idx: j, keyType: kt}
 			switch kt {
 			case "string":
-				vc.strCmd = valuePipe.Get(c.ctx, key)
+				vc.strCmd = valuePipe.GetRange(c.ctx, key, 0, searchMaxStringBytes-1)
 			case "hash":
-				vc.hashCmd = valuePipe.HGetAll(c.ctx, key)
+				vc.hashCmd = valuePipe.HScan(c.ctx, key, 0, "", int64(searchMaxItems))
 			case "list":
-				vc.listCmd = valuePipe.LRange(c.ctx, key, 0, -1)
+				vc.listCmd = valuePipe.LRange(c.ctx, key, 0, int64(searchMaxItems-1))
 			case "set":
-				vc.setCmd = valuePipe.SMembers(c.ctx, key)
+				vc.setCmd = valuePipe.SScan(c.ctx, key, 0, "", int64(searchMaxItems))
 			case "ReJSON-RL":
 				vc.jsonCmd = valuePipe.Do(c.ctx, "JSON.GET", key, "$")
 			default:
@@ -324,57 +356,28 @@ func (c *Client) SearchByValue(pattern string, valueSearch string, maxKeys int) 
 			}
 			valueCmds = append(valueCmds, vc)
 		}
-		_, _ = valuePipe.Exec(c.ctx)
+		if len(valueCmds) > 0 {
+			_, _ = valuePipe.Exec(c.ctx)
+		}
 
-		// Find matching keys
 		for _, vc := range valueCmds {
-			found := false
-			switch vc.keyType {
-			case "string":
-				val, _ := vc.strCmd.Result()
-				found = strings.Contains(val, valueSearch)
-			case "hash":
-				vals, _ := vc.hashCmd.Result()
-				for _, v := range vals {
-					if strings.Contains(v, valueSearch) {
-						found = true
-						break
-					}
-				}
-			case "list":
-				vals, _ := vc.listCmd.Result()
-				for _, v := range vals {
-					if strings.Contains(v, valueSearch) {
-						found = true
-						break
-					}
-				}
-			case "set":
-				vals, _ := vc.setCmd.Result()
-				for _, v := range vals {
-					if strings.Contains(v, valueSearch) {
-						found = true
-						break
-					}
-				}
-			case "ReJSON-RL":
-				val, _ := vc.jsonCmd.Text()
-				found = strings.Contains(val, valueSearch)
-			}
-			if found {
+			if valueCmdMatches(vc.keyType, valueSearch, vc.strCmd, vc.hashCmd, vc.listCmd, vc.setCmd, vc.jsonCmd) {
 				matches = append(matches, match{key: keys[vc.idx], keyType: keyTypes[vc.idx]})
 				if len(matches) >= maxKeys {
-					break
+					return false
 				}
 			}
 		}
+		return true
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if len(matches) == 0 {
 		return []types.RedisKey{}, nil
 	}
 
-	// Single final pipeline for TTL of all matches
 	ttlPipe := c.pipeline()
 	ttlCmds := make([]*redis.DurationCmd, len(matches))
 	for j, m := range matches {
@@ -391,8 +394,65 @@ func (c *Client) SearchByValue(pattern string, valueSearch string, maxKeys int) 
 			TTL:  ttl,
 		}
 	}
-
 	return result, nil
+}
+
+func valueCmdMatches(
+	keyType, valueSearch string,
+	strCmd *redis.StringCmd,
+	hashCmd *redis.ScanCmd,
+	listCmd *redis.StringSliceCmd,
+	setCmd *redis.ScanCmd,
+	jsonCmd *redis.Cmd,
+) bool {
+	switch keyType {
+	case "string":
+		if strCmd == nil {
+			return false
+		}
+		val, _ := strCmd.Result()
+		return strings.Contains(val, valueSearch)
+	case "hash":
+		if hashCmd == nil {
+			return false
+		}
+		batch, _, _ := hashCmd.Result()
+		for i := 0; i+1 < len(batch); i += 2 {
+			if strings.Contains(batch[i+1], valueSearch) {
+				return true
+			}
+		}
+	case "list":
+		if listCmd == nil {
+			return false
+		}
+		vals, _ := listCmd.Result()
+		for _, v := range vals {
+			if strings.Contains(v, valueSearch) {
+				return true
+			}
+		}
+	case "set":
+		if setCmd == nil {
+			return false
+		}
+		vals, _, _ := setCmd.Result()
+		for _, v := range vals {
+			if strings.Contains(v, valueSearch) {
+				return true
+			}
+		}
+	case "ReJSON-RL":
+		if jsonCmd == nil {
+			return false
+		}
+		val, err := jsonCmd.Text()
+		if err != nil {
+			return false
+		}
+		return strings.Contains(val, valueSearch)
+	}
+	return false
 }
 
 // GetKeyPrefixes returns all unique key prefixes (for tree view).

--- a/internal/redis/enumeration_test.go
+++ b/internal/redis/enumeration_test.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"container/heap"
 	"fmt"
 	"sort"
 	"strings"
@@ -702,7 +703,7 @@ func TestFuzzySearchKeys_ScanError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// SearchByValue — scanAll error path.
+// SearchByValue — scanEach error path.
 // ---------------------------------------------------------------------------
 
 func TestSearchByValue_ScanError(t *testing.T) {
@@ -1140,5 +1141,300 @@ func BenchmarkScanKeysProtobufMenus(b *testing.B) {
 		if _, _, err := client.ScanKeys("menu:v4:*", 0, 100); err != nil {
 			b.Fatalf("ScanKeys: %v", err)
 		}
+	}
+}
+
+func TestFuzzySearchKeys_TopNOnLargeKeyspace(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	for i := 0; i < 500; i++ {
+		mr.Set(fmt.Sprintf("noise:%04d", i), "v")
+	}
+	// Longer substring matches score higher: 100 + (len - len("target"))
+	mr.Set("target", "exact")
+	mr.Set("target:short", "a")
+	mr.Set("target:medium:key", "b")
+	mr.Set("target:the:longest:match:key", "c")
+	for i := 0; i < 200; i++ {
+		mr.Set(fmt.Sprintf("target:bulk:%04d", i), "v")
+	}
+
+	results, err := client.FuzzySearchKeys("target", 5)
+	if err != nil {
+		t.Fatalf("FuzzySearchKeys error: %v", err)
+	}
+	if len(results) != 5 {
+		t.Fatalf("results length = %d, want 5", len(results))
+	}
+
+	// Highest substring score among seeded keys is the longest containing "target".
+	if results[0].Key != "target:the:longest:match:key" {
+		t.Errorf("top result = %q, want target:the:longest:match:key", results[0].Key)
+	}
+	for _, r := range results {
+		if !strings.Contains(strings.ToLower(r.Key), "target") {
+			t.Errorf("unexpected key %q in top-N", r.Key)
+		}
+		if r.Type == "" {
+			t.Errorf("key %q missing type", r.Key)
+		}
+	}
+}
+
+func TestFuzzySearchKeys_DefaultMaxKeys(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	for i := 0; i < 5; i++ {
+		mr.Set(fmt.Sprintf("user:%d", i), "v")
+	}
+
+	results, err := client.FuzzySearchKeys("user", 0)
+	if err != nil {
+		t.Fatalf("FuzzySearchKeys error: %v", err)
+	}
+	if len(results) != 5 {
+		t.Fatalf("results length = %d, want 5 (default maxKeys path)", len(results))
+	}
+
+	results, err = client.FuzzySearchKeys("user", -3)
+	if err != nil {
+		t.Fatalf("FuzzySearchKeys negative maxKeys error: %v", err)
+	}
+	if len(results) != 5 {
+		t.Fatalf("results length = %d, want 5 for negative maxKeys", len(results))
+	}
+}
+
+func TestScoreMinHeapConsider(t *testing.T) {
+	var h scoreMinHeap
+	h.consider(scoredKey{key: "a", score: 10}, 0)
+	if h.Len() != 0 {
+		t.Fatalf("consider with maxKeys=0 should keep empty heap, got %d", h.Len())
+	}
+
+	h.consider(scoredKey{key: "low", score: 1}, 2)
+	h.consider(scoredKey{key: "mid", score: 5}, 2)
+	h.consider(scoredKey{key: "high", score: 9}, 2)
+	h.consider(scoredKey{key: "lower", score: 0}, 2)
+	if h.Len() != 2 {
+		t.Fatalf("heap len = %d, want 2", h.Len())
+	}
+
+	got := map[string]int{}
+	for h.Len() > 0 {
+		sk := heap.Pop(&h).(scoredKey)
+		got[sk.key] = sk.score
+	}
+	if _, ok := got["high"]; !ok {
+		t.Errorf("expected high in heap, got %v", got)
+	}
+	if _, ok := got["mid"]; !ok {
+		t.Errorf("expected mid in heap, got %v", got)
+	}
+	if _, ok := got["low"]; ok {
+		t.Errorf("low should have been evicted, got %v", got)
+	}
+}
+
+func TestSearchByValue_EarlyStopAtMaxKeys(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	// Far more matching keys than maxKeys; scan must stop once maxKeys matches.
+	for i := 0; i < 300; i++ {
+		mr.Set(fmt.Sprintf("sv:%04d", i), "needle-value")
+	}
+
+	results, err := client.SearchByValue("*", "needle", 7)
+	if err != nil {
+		t.Fatalf("SearchByValue error: %v", err)
+	}
+	if len(results) != 7 {
+		t.Fatalf("results length = %d, want 7", len(results))
+	}
+}
+
+func TestSearchByValue_GetRangePrefixMatch(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	// Needle near the start of a large string; GETRANGE prefix must still match.
+	large := "prefix-needle-" + strings.Repeat("x", int(searchMaxStringBytes)+4096)
+	mr.Set("big:string", large)
+
+	// Non-matching large string to exercise the miss path.
+	mr.Set("big:other", strings.Repeat("z", int(searchMaxStringBytes)+1024))
+
+	results, err := client.SearchByValue("big:*", "needle", 10)
+	if err != nil {
+		t.Fatalf("SearchByValue error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results length = %d, want 1", len(results))
+	}
+	if results[0].Key != "big:string" {
+		t.Errorf("key = %q, want big:string", results[0].Key)
+	}
+	if results[0].Type != types.KeyTypeString {
+		t.Errorf("type = %q, want string", results[0].Type)
+	}
+}
+
+func TestSearchByValue_BoundedCollections(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	mr.RPush("list:hit", "has-needle-here")
+	for i := 0; i < searchMaxItems+50; i++ {
+		mr.RPush("list:hit", fmt.Sprintf("item-%d", i))
+	}
+
+	mr.HSet("hash:hit", "f1", "plain")
+	mr.HSet("hash:hit", "f2", "contains-needle")
+	mr.SAdd("set:hit", "alpha", "needle-member", "beta")
+
+	// Non-matching collection entries must not match or panic.
+	mr.RPush("list:miss", "foo", "bar")
+	mr.HSet("hash:miss", "f", "plain")
+	mr.SAdd("set:miss", "alpha", "beta")
+	mr.Set("str:miss", "nothing-here")
+
+	results, err := client.SearchByValue("*", "needle", 10)
+	if err != nil {
+		t.Fatalf("SearchByValue error: %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, r := range results {
+		found[r.Key] = true
+	}
+	for _, want := range []string{"list:hit", "hash:hit", "set:hit"} {
+		if !found[want] {
+			t.Errorf("missing expected key %q in %v", want, found)
+		}
+	}
+	for _, unwant := range []string{"list:miss", "hash:miss", "set:miss", "str:miss"} {
+		if found[unwant] {
+			t.Errorf("unexpected non-match key %q", unwant)
+		}
+	}
+}
+
+func TestSearchByValue_EmptyAndMissingNoPanic(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	// Empty DB / missing keys must not panic.
+	results, err := client.SearchByValue("*", "needle", 10)
+	if err != nil {
+		t.Fatalf("SearchByValue empty db error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results on empty db, got %d", len(results))
+	}
+
+	mr.Set("present", "hello")
+
+	results, err = client.SearchByValue("missing:*", "needle", 10)
+	if err != nil {
+		t.Fatalf("SearchByValue missing pattern error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for missing pattern, got %d", len(results))
+	}
+
+	results, err = client.SearchByValue("", "hello", 10)
+	if err != nil {
+		t.Fatalf("SearchByValue empty pattern error: %v", err)
+	}
+	if len(results) != 1 || results[0].Key != "present" {
+		t.Errorf("empty pattern results = %v, want [present]", results)
+	}
+
+	results, err = client.SearchByValue("*", "hello", 0)
+	if err != nil {
+		t.Fatalf("SearchByValue default maxKeys error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("default maxKeys results = %d, want 1", len(results))
+	}
+
+	results, err = client.SearchByValue("*", "hello", -1)
+	if err != nil {
+		t.Fatalf("SearchByValue negative maxKeys error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("negative maxKeys results = %d, want 1", len(results))
+	}
+}
+
+func TestValueCmdMatches_NilAndBranches(t *testing.T) {
+	if valueCmdMatches("string", "x", nil, nil, nil, nil, nil) {
+		t.Error("nil string cmd should not match")
+	}
+	if valueCmdMatches("hash", "x", nil, nil, nil, nil, nil) {
+		t.Error("nil hash cmd should not match")
+	}
+	if valueCmdMatches("list", "x", nil, nil, nil, nil, nil) {
+		t.Error("nil list cmd should not match")
+	}
+	if valueCmdMatches("set", "x", nil, nil, nil, nil, nil) {
+		t.Error("nil set cmd should not match")
+	}
+	if valueCmdMatches("ReJSON-RL", "x", nil, nil, nil, nil, nil) {
+		t.Error("nil json cmd should not match")
+	}
+	if valueCmdMatches("zset", "x", nil, nil, nil, nil, nil) {
+		t.Error("unsupported type should not match")
+	}
+}
+
+func TestSearchByValue_HashFieldNoValueMatch(t *testing.T) {
+	client, mr := setupTestClient(t)
+
+	// Field name contains needle but value does not — hash match checks values only.
+	mr.HSet("hash:fieldonly", "needle-field", "plain-value")
+	mr.HSet("hash:valuehit", "f", "has-needle")
+
+	results, err := client.SearchByValue("*", "needle", 10)
+	if err != nil {
+		t.Fatalf("SearchByValue error: %v", err)
+	}
+	found := map[string]bool{}
+	for _, r := range results {
+		found[r.Key] = true
+	}
+	if !found["hash:valuehit"] {
+		t.Error("expected hash:valuehit")
+	}
+	if found["hash:fieldonly"] {
+		t.Error("hash field names must not match; only values")
+	}
+}
+
+func TestSearchByValue_ReJSONTextError(t *testing.T) {
+	srv := newFakeRedisServer(t)
+	srv.setHandler(func(argv []string) string {
+		switch argv[0] {
+		case "SCAN":
+			return "*2\r\n$1\r\n0\r\n*1\r\n$5\r\nkjson\r\n"
+		case "TYPE":
+			return "+ReJSON-RL\r\n"
+		case "JSON.GET":
+			return "-ERR injected\r\n"
+		case "TTL":
+			return ":-1\r\n"
+		}
+		return ""
+	})
+	host, port := srv.addr()
+	c := NewClient()
+	if err := c.Connect(types.Connection{Name: "test", Host: host, Port: port, DB: 0, UseCluster: false}); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Disconnect() })
+
+	results, err := c.SearchByValue("*", "needle", 10)
+	if err != nil {
+		t.Fatalf("SearchByValue error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results when JSON.GET errors, got %v", results)
 	}
 }


### PR DESCRIPTION
## Summary

Makes `FuzzySearchKeys` and `SearchByValue` scale better on large keyspaces by avoiding full-keyspace materialization and unbounded value fetches.

### FuzzySearchKeys
- Keeps a **bounded min-heap of size `maxKeys`** while scanning so memory is O(maxKeys), not O(matches)
- Still scans the full keyspace for correct global top-N ranking
- After scan, sorts the final top-N by score descending and pipelines Type/TTL as before
- `maxKeys <= 0` falls back to a default of 100

### SearchByValue
- **Streams** via `scanEach` instead of `scanAll` (no full key list in memory)
- **Early-stops** once `len(matches) >= maxKeys`
- Bounds value fetches used only for substring matching:
  - strings: `GETRANGE` first 64KB (`searchMaxStringBytes`)
  - lists: `LRANGE 0..searchMaxItems-1` (100)
  - hashes/sets: single `HSCAN`/`SSCAN` with COUNT 100
  - ReJSON: still full `JSON.GET` (no bounded Redis API)
- Final TTL pipeline runs only for matched keys
- `maxKeys <= 0` / empty pattern defaults applied

### Trade-off (intentional)
Value search only inspects a **prefix window** of each value. Matches that exist only outside that window (deep in a large string/list/hash/set) may be missed. Acceptable for interactive TUI search; full materialization was the previous cost.

## Test plan
- [x] `go test -race ./internal/redis/...`
- [x] Fuzzy top-N on large synthetic keyspace (500+ noise keys)
- [x] SearchByValue early-stops at maxKeys
- [x] Large string GETRANGE prefix match when needle is near start
- [x] Bounded list/hash/set match paths
- [x] Empty DB / missing pattern / nil cmd branches do not panic
- [x] ReJSON match + JSON.GET error path
- [x] 100% statement coverage on changed functions

## Out of scope
- GetValue detail path (owned by parallel work)
- UI debounce (owned by parallel work)
