### PR TITLE
feat: seed protobuf/s2 and skip stack by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
 
 .PHONY: all build install clean test bench test-cover test-cover-check lint run start release snapshot demo \
-	docker-up docker-down docker-seed \
+	docker-up docker-down docker-seed docker-up-all docker-down-all docker-seed-all \
 	docker-up-standalone docker-up-standalone-stack docker-up-cluster docker-up-cluster-stack \
 	docker-down-standalone docker-down-standalone-stack docker-down-cluster docker-down-cluster-stack \
 	docker-seed-standalone docker-seed-standalone-stack docker-seed-cluster docker-seed-cluster-stack
@@ -110,14 +110,19 @@ dev-deps:
 
 ## --- Docker Examples ---
 
-## Start all example Redis instances
-docker-up: docker-up-standalone docker-up-standalone-stack docker-up-cluster docker-up-cluster-stack
+## Start default example Redis instances (plain redis only — no redis-stack)
+docker-up: docker-up-standalone docker-up-cluster
 
-## Stop all example Redis instances
-docker-down: docker-down-standalone docker-down-standalone-stack docker-down-cluster docker-down-cluster-stack
+## Stop default example Redis instances
+docker-down: docker-down-standalone docker-down-cluster
 
-## Seed all running example instances
-docker-seed: docker-seed-standalone docker-seed-standalone-stack docker-seed-cluster docker-seed-cluster-stack
+## Seed default example instances
+docker-seed: docker-seed-standalone docker-seed-cluster
+
+## Start / stop / seed every compose file including redis-stack
+docker-up-all: docker-up-standalone docker-up-standalone-stack docker-up-cluster docker-up-cluster-stack
+docker-down-all: docker-down-standalone docker-down-standalone-stack docker-down-cluster docker-down-cluster-stack
+docker-seed-all: docker-seed-standalone docker-seed-standalone-stack docker-seed-cluster docker-seed-cluster-stack
 
 ## Standalone (redis:7-alpine on :6379)
 docker-up-standalone:
@@ -188,9 +193,12 @@ help:
 	@echo "    dev-deps    - Install development dependencies"
 	@echo ""
 	@echo "  Docker Examples:"
-	@echo "    docker-up                  - Start all instances"
-	@echo "    docker-down                - Stop all instances"
-	@echo "    docker-seed                - Seed all instances"
+	@echo "    docker-up                  - Start default instances (standalone + cluster)"
+	@echo "    docker-down                - Stop default instances"
+	@echo "    docker-seed                - Seed default instances"
+	@echo "    docker-up-all              - Start all instances including redis-stack"
+	@echo "    docker-down-all            - Stop all instances including redis-stack"
+	@echo "    docker-seed-all            - Seed all instances including redis-stack"
 	@echo "    docker-up-standalone       - Standalone (:6379)"
 	@echo "    docker-up-standalone-stack - Standalone Redis Stack (:6390)"
 	@echo "    docker-up-cluster          - Cluster (:6380-6385)"

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ docker compose -f examples/cluster-redis-stack/docker-compose.yml up -d
 redis-tui -h localhost -p 6386 --cluster
 ```
 
-The `Makefile` also exposes shortcuts for these (`make docker-up-standalone`, `make docker-up-cluster`, `make docker-up-standalone-stack`, `make docker-up-cluster-stack`) along with matching `docker-down-*` and `docker-seed-*` targets.
+`make docker-up` / `make docker-seed` start and seed the default plain Redis instances (standalone + cluster). Redis Stack is optional via `make docker-up-standalone-stack`, `make docker-up-cluster-stack`, or `make docker-up-all`.
 
 ## Configuration
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,16 +41,17 @@ redis-tui -c localhost:6386
 ## Makefile Shortcuts
 
 ```sh
-make docker-up     # Start all four instances
-make docker-down   # Stop all four instances
-make docker-seed   # Seed all four instances
+make docker-up     # Start default instances (standalone + cluster, plain redis)
+make docker-down   # Stop default instances
+make docker-seed   # Seed default instances
+make docker-up-all # Also start redis-stack compose files
 ```
 
-Individual targets are also available (e.g. `make docker-up-standalone-stack`). Run `make help` for the full list.
+Redis Stack remains optional via `make docker-up-standalone-stack` / `make docker-up-cluster-stack` (or `make docker-up-all`). Run `make help` for the full list.
 
 ## Seed Data
 
-Populate an instance with sample data covering every data type. Native RedisJSON keys are seeded automatically when the module is available (Redis Stack), otherwise they are skipped gracefully.
+Populate an instance with sample data covering every data type — including raw protobuf and s2-compressed protobuf strings for the TUI decoder. Native RedisJSON keys are seeded automatically when the module is available (Redis Stack), otherwise they are skipped gracefully.
 
 ```sh
 # Standalone (localhost:6379)

--- a/examples/seed/main.go
+++ b/examples/seed/main.go
@@ -13,7 +13,9 @@ import (
 	"net"
 	"time"
 
+	"github.com/klauspost/compress/s2"
 	"github.com/redis/go-redis/v9"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func main() {
@@ -76,6 +78,7 @@ func runSeeds(ctx context.Context, rdb redis.Cmdable) {
 	seedTTLKeys(ctx, rdb)
 	seedNestedKeys(ctx, rdb)
 	seedJSONStrings(ctx, rdb)
+	seedProtobuf(ctx, rdb)
 	if checkJSON(ctx, rdb) {
 		seedJSON(ctx, rdb)
 	} else {
@@ -324,6 +327,71 @@ func seedJSONStrings(ctx context.Context, rdb redis.Cmdable) {
 		must(rdb.Set(ctx, k, v, 0))
 	}
 	fmt.Printf("  json strings: %d keys\n", len(jsons))
+}
+
+func seedProtobuf(ctx context.Context, rdb redis.Cmdable) {
+	user := protoJoin(
+		protoString(1, "Alice Johnson"),
+		protoString(2, "alice@example.com"),
+		protoVarint(3, 1001),
+		protoNested(4, protoJoin(protoString(1, "dark"), protoString(2, "en"))),
+	)
+	must(rdb.Set(ctx, "pb:user-profile", user, 0))
+
+	delivery := protoJoin(
+		protoString(1, "rst-demo:DELIVERY"),
+		protoString(3, "America/Toronto"),
+		protoVarint(5, 42),
+	)
+	must(rdb.Set(ctx, "pb:delivery", delivery, 0))
+
+	menu := protoJoin(
+		protoString(1, "menu-id"),
+		protoNested(4, protoJoin(
+			protoString(1, "cat-1"),
+			protoNested(2, protoJoin(protoString(1, "item-1"), protoString(2, "Margherita"))),
+		)),
+	)
+	must(rdb.Set(ctx, "pb:s2:menu", s2.Encode(nil, menu), 0))
+
+	session := protoJoin(
+		protoString(1, "sess-abc123"),
+		protoVarint(2, 1001),
+		protoString(3, "192.168.1.42"),
+		protoNested(4, protoJoin(protoString(1, "web"), protoVarint(2, 1))),
+	)
+	must(rdb.Set(ctx, "pb:s2:session", s2.Encode(nil, session), 0))
+
+	fmt.Println("  protobuf:     4 keys (2 raw, 2 s2+protobuf)")
+}
+
+func protoJoin(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+func protoString(num protowire.Number, s string) []byte {
+	var b []byte
+	b = protowire.AppendTag(b, num, protowire.BytesType)
+	b = protowire.AppendString(b, s)
+	return b
+}
+
+func protoVarint(num protowire.Number, v uint64) []byte {
+	var b []byte
+	b = protowire.AppendTag(b, num, protowire.VarintType)
+	b = protowire.AppendVarint(b, v)
+	return b
+}
+
+func protoNested(num protowire.Number, inner []byte) []byte {
+	var b []byte
+	b = protowire.AppendTag(b, num, protowire.BytesType)
+	b = protowire.AppendBytes(b, inner)
+	return b
 }
 
 func hasJSONModule(ctx context.Context, rdb redis.Cmdable) bool {

--- a/examples/seed/main_test.go
+++ b/examples/seed/main_test.go
@@ -5,10 +5,12 @@ import (
 	"flag"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/alicebob/miniredis/v2/server"
+	"github.com/davidbudnick/redis-tui/internal/decode"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -146,6 +148,38 @@ func TestSeedJSONStrings(t *testing.T) {
 	seedJSONStrings(context.Background(), rdb)
 	if !mr.Exists("json:user-profile") {
 		t.Error("json:user-profile should exist")
+	}
+}
+
+func TestSeedProtobuf(t *testing.T) {
+	mr, rdb := setupMiniRedis(t)
+	seedProtobuf(context.Background(), rdb)
+
+	for _, key := range []string{"pb:user-profile", "pb:delivery", "pb:s2:menu", "pb:s2:session"} {
+		if !mr.Exists(key) {
+			t.Errorf("%s should exist", key)
+		}
+	}
+
+	raw, err := mr.Get("pb:delivery")
+	if err != nil {
+		t.Fatalf("get pb:delivery: %v", err)
+	}
+	got, ok := decode.TryBinary([]byte(raw))
+	if !ok || got.Format != "protobuf" {
+		t.Fatalf("pb:delivery format = %q ok=%v, want protobuf", got.Format, ok)
+	}
+
+	compressed, err := mr.Get("pb:s2:menu")
+	if err != nil {
+		t.Fatalf("get pb:s2:menu: %v", err)
+	}
+	got, ok = decode.TryBinary([]byte(compressed))
+	if !ok || got.Format != "s2+protobuf" {
+		t.Fatalf("pb:s2:menu format = %q ok=%v, want s2+protobuf", got.Format, ok)
+	}
+	if !strings.Contains(got.Text, "menu-id") {
+		t.Errorf("decoded menu missing menu-id:\n%s", got.Text)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Seed raw protobuf and s2-compressed protobuf sample keys (`pb:*`, `pb:s2:*`) so the TUI decoder is easy to demo on plain Redis
- Make `make docker-up` / `docker-down` / `docker-seed` default to standalone + cluster only (no redis-stack)
- Keep redis-stack available via `make docker-up-all` and the existing `*-stack` targets

## Test plan
- [x] `go test -race ./examples/seed/`
- [x] `make build`
- [x] `make -n docker-up docker-seed` shows only standalone + cluster
- [ ] `make docker-up docker-seed` then browse `pb:` / `pb:s2:` keys in the TUI