### PR TITLE
fix: don't fire q/? while typing in inputs

### DIFF
--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -277,6 +277,9 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, m.Cmds.CopyToClipboard(value)
 		}
 	case "q":
+		if m.textEntryActive() {
+			break
+		}
 		if m.Screen == types.ScreenConnections {
 			return m, tea.Quit
 		}
@@ -284,6 +287,9 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 	case "?":
+		if m.textEntryActive() {
+			break
+		}
 		if m.Screen != types.ScreenHelp && m.Screen != types.ScreenAddConnection &&
 			m.Screen != types.ScreenEditConnection && m.Screen != types.ScreenAddKey &&
 			m.Screen != types.ScreenTTLEditor {

--- a/internal/ui/update_copy.go
+++ b/internal/ui/update_copy.go
@@ -5,6 +5,17 @@ import (
 	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
+// textEntryActive reports whether the current screen is capturing free-form
+// text, in which case single-letter global shortcuts (q, ?) must not fire —
+// otherwise typing a filter like "sidekiq" quits the app.
+func (m Model) textEntryActive() bool {
+	if m.Screen == types.ScreenEditValue && m.VimEditor != nil {
+		return true
+	}
+	_, focused := m.focusedInputValue()
+	return focused
+}
+
 // focusedInputValue returns the text of the focused input on the current screen.
 func (m Model) focusedInputValue() (string, bool) {
 	switch m.Screen {

--- a/internal/ui/update_copy.go
+++ b/internal/ui/update_copy.go
@@ -5,9 +5,7 @@ import (
 	"github.com/davidbudnick/redis-tui/internal/types"
 )
 
-// textEntryActive reports whether the current screen is capturing free-form
-// text, in which case single-letter global shortcuts (q, ?) must not fire —
-// otherwise typing a filter like "sidekiq" quits the app.
+// textEntryActive reports whether a text input or the value editor is capturing keys.
 func (m Model) textEntryActive() bool {
 	if m.Screen == types.ScreenEditValue && m.VimEditor != nil {
 		return true

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -400,6 +400,15 @@ func TestHandleKeyPress_GlobalKeys(t *testing.T) {
 			t.Errorf("expected ? in filter, got %q", got)
 		}
 	})
+	t.Run("? typed into vim editor does not open help", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenEditValue
+		m.VimEditor = createVimEditor("value", 80, 24, "key")
+		result, _ := m.handleKeyPress(keyMsg('?'))
+		if result.(Model).Screen != types.ScreenEditValue {
+			t.Errorf("expected ScreenEditValue, got %v", result.(Model).Screen)
+		}
+	})
 }
 
 func TestTextEntryActive(t *testing.T) {

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -377,6 +377,56 @@ func TestHandleKeyPress_GlobalKeys(t *testing.T) {
 			t.Error("expected screen unchanged")
 		}
 	})
+	t.Run("q typed into key filter does not quit", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenKeys
+		m.Inputs.PatternInput.Focus()
+		m.Inputs.PatternInput.SetValue("sideki")
+		result, _ := m.handleKeyPress(keyMsg('q'))
+		if got := result.(Model).Inputs.PatternInput.Value(); got != "sidekiq" {
+			t.Errorf("expected sidekiq in filter, got %q", got)
+		}
+	})
+	t.Run("? typed into key filter does not open help", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenKeys
+		m.Inputs.PatternInput.Focus()
+		result, _ := m.handleKeyPress(keyMsg('?'))
+		updated := result.(Model)
+		if updated.Screen != types.ScreenKeys {
+			t.Errorf("expected ScreenKeys, got %v", updated.Screen)
+		}
+		if got := updated.Inputs.PatternInput.Value(); got != "?" {
+			t.Errorf("expected ? in filter, got %q", got)
+		}
+	})
+}
+
+func TestTextEntryActive(t *testing.T) {
+	t.Run("vim editor active", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenEditValue
+		m.VimEditor = createVimEditor("value", 80, 24, "key")
+		if !m.textEntryActive() {
+			t.Error("expected text entry active with vim editor")
+		}
+	})
+	t.Run("focused input active", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenKeys
+		m.Inputs.PatternInput.Focus()
+		if !m.textEntryActive() {
+			t.Error("expected text entry active with focused filter")
+		}
+	})
+	t.Run("no input inactive", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.Screen = types.ScreenKeys
+		m.Inputs.PatternInput.Blur()
+		if m.textEntryActive() {
+			t.Error("expected text entry inactive")
+		}
+	})
 }
 
 func TestHandleKeyPress_AllScreens(t *testing.T) {


### PR DESCRIPTION
## Problem

I tried using this application after looking for something to let me inspect my redis DB using a TUI interface. It works pretty well!

However, the thing I was looking for was "sidekiq". Most of those letters work, except the last one. Took me 3 tries before I realised what was happening. 

Here's a fix for it. Below is what the robot output.

---

Typing a key filter containing `q` quits the app. `handleKeyPress` checks
global single-letter shortcuts before dispatching to the screen handler, so
filtering for `sidekiq` hits `tea.Quit` on the final character.

Same root cause affects `?`: it jumps to the help screen while typing in any
focused text input, and from inside the vim value editor.

## Fix

New `Model.textEntryActive()` reports whether the current screen is capturing
free-form text — the vim editor is open, or an input on the current screen has
focus. The global `q` and `?` cases now break out to screen dispatch when it
returns true. `ctrl+c` still quits unconditionally.

## Tests

- `q` and `?` typed into a focused key filter land in the input instead of
  quitting / opening help
- All three `textEntryActive()` branches

Full suite passes with `-race`; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
