### PR TITLE
fix: auto-dismiss status bar toasts

### DIFF
--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -154,6 +154,11 @@ type TickMsg struct{}
 
 type WatchTickMsg struct{}
 
+// StatusClearMsg dismisses a transient status bar toast after its timer fires.
+type StatusClearMsg struct {
+	ID int
+}
+
 type SearchDebounceMsg struct {
 	Seq int
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -40,6 +40,7 @@ type Model struct {
 	Height            int
 	Err               error
 	StatusMsg         string
+	statusID          int
 	Loading           bool
 	ConfirmType       string
 	ConfirmData       any

--- a/internal/ui/screens_keys.go
+++ b/internal/ui/screens_keys.go
@@ -101,6 +101,7 @@ func (m Model) handleKeysScreen(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			key := m.Keys[m.SelectedKeyIdx]
 			m.CurrentKey = &key
 			m.Loading = true
+			m.StatusMsg = ""
 			m.SelectedItemIdx = 0
 			return m, tea.Batch(m.Cmds.LoadKeyValue(key.Key), m.Cmds.GetMemoryUsage(key.Key))
 		}

--- a/internal/ui/screens_keys_test.go
+++ b/internal/ui/screens_keys_test.go
@@ -235,9 +235,13 @@ func TestHandleKeysScreen_Actions(t *testing.T) {
 	t.Run("enter opens detail", func(t *testing.T) {
 		m, _, _ := newTestModel(t)
 		seedKeys(&m, 3)
-		_, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyEnter})
+		m.StatusMsg = "Connected"
+		result, cmd := m.handleKeysScreen(tea.KeyPressMsg{Code: tea.KeyEnter})
 		if cmd == nil {
 			t.Error("expected load value cmd")
+		}
+		if result.(Model).StatusMsg != "" {
+			t.Errorf("StatusMsg = %q, want empty after inspect", result.(Model).StatusMsg)
 		}
 	})
 	t.Run("enter empty", func(t *testing.T) {

--- a/internal/ui/status.go
+++ b/internal/ui/status.go
@@ -1,0 +1,71 @@
+package ui
+
+import (
+	"strings"
+	"time"
+
+	"github.com/davidbudnick/redis-tui/internal/types"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+const (
+	statusFlashDuration = 2 * time.Second
+	statusErrorDuration = 4 * time.Second
+)
+
+func (m Model) handleStatusClear(msg types.StatusClearMsg) (tea.Model, tea.Cmd) {
+	if msg.ID == m.statusID {
+		m.StatusMsg = ""
+	}
+	return m, nil
+}
+
+func (m *Model) scheduleStatusClear(prev string) tea.Cmd {
+	if m.StatusMsg == prev {
+		return nil
+	}
+	m.statusID++
+	if m.StatusMsg == "" || isStickyStatus(m.StatusMsg) {
+		return nil
+	}
+	return statusClearAfter(m.statusID, statusDuration(m.StatusMsg))
+}
+
+func statusClearAfter(id int, d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(time.Time) tea.Msg {
+		return types.StatusClearMsg{ID: id}
+	})
+}
+
+func statusDuration(msg string) time.Duration {
+	if isErrorStatus(msg) {
+		return statusErrorDuration
+	}
+	return statusFlashDuration
+}
+
+func isStickyStatus(msg string) bool {
+	switch msg {
+	case "Connecting...", "Watching key for changes...":
+		return true
+	default:
+		return false
+	}
+}
+
+func isErrorStatus(msg string) bool {
+	if strings.HasPrefix(msg, "Error") {
+		return true
+	}
+	if strings.Contains(msg, "failed") {
+		return true
+	}
+	if strings.Contains(strings.ToLower(msg), "error:") {
+		return true
+	}
+	if strings.HasPrefix(msg, "Invalid ") {
+		return true
+	}
+	return false
+}

--- a/internal/ui/status_test.go
+++ b/internal/ui/status_test.go
@@ -1,0 +1,194 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/davidbudnick/redis-tui/internal/types"
+)
+
+func TestHandleStatusClear(t *testing.T) {
+	t.Run("matching id clears status", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.StatusMsg = "Value updated"
+		m.statusID = 3
+		result, cmd := m.handleStatusClear(types.StatusClearMsg{ID: 3})
+		if cmd != nil {
+			t.Fatal("expected nil cmd")
+		}
+		if result.(Model).StatusMsg != "" {
+			t.Errorf("StatusMsg = %q, want empty", result.(Model).StatusMsg)
+		}
+	})
+	t.Run("stale id leaves status", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.StatusMsg = "Value updated"
+		m.statusID = 4
+		result, cmd := m.handleStatusClear(types.StatusClearMsg{ID: 3})
+		if cmd != nil {
+			t.Fatal("expected nil cmd")
+		}
+		if result.(Model).StatusMsg != "Value updated" {
+			t.Errorf("StatusMsg = %q, want %q", result.(Model).StatusMsg, "Value updated")
+		}
+	})
+}
+
+func TestScheduleStatusClear(t *testing.T) {
+	t.Run("unchanged status is a no-op", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.StatusMsg = "Value updated"
+		m.statusID = 2
+		if cmd := m.scheduleStatusClear("Value updated"); cmd != nil {
+			t.Fatal("expected nil cmd")
+		}
+		if m.statusID != 2 {
+			t.Errorf("statusID = %d, want 2", m.statusID)
+		}
+	})
+	t.Run("cleared status invalidates pending toast", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.StatusMsg = ""
+		m.statusID = 2
+		if cmd := m.scheduleStatusClear("Value updated"); cmd != nil {
+			t.Fatal("expected nil cmd")
+		}
+		if m.statusID != 3 {
+			t.Errorf("statusID = %d, want 3", m.statusID)
+		}
+	})
+	t.Run("sticky status is not timed out", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.StatusMsg = "Connecting..."
+		if cmd := m.scheduleStatusClear(""); cmd != nil {
+			t.Fatal("expected nil cmd for sticky status")
+		}
+		if m.statusID != 1 {
+			t.Errorf("statusID = %d, want 1", m.statusID)
+		}
+	})
+	t.Run("transient status schedules clear", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.StatusMsg = "Value updated"
+		cmd := m.scheduleStatusClear("")
+		if cmd == nil {
+			t.Fatal("expected clear cmd")
+		}
+		if m.statusID != 1 {
+			t.Errorf("statusID = %d, want 1", m.statusID)
+		}
+	})
+}
+
+func TestStatusClearAfter(t *testing.T) {
+	cmd := statusClearAfter(7, time.Millisecond)
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	msg := cmd()
+	clear, ok := msg.(types.StatusClearMsg)
+	if !ok {
+		t.Fatalf("expected StatusClearMsg, got %T", msg)
+	}
+	if clear.ID != 7 {
+		t.Errorf("ID = %d, want 7", clear.ID)
+	}
+}
+
+func TestStatusDuration(t *testing.T) {
+	if got := statusDuration("Value updated"); got != statusFlashDuration {
+		t.Errorf("success duration = %v, want %v", got, statusFlashDuration)
+	}
+	if got := statusDuration("Error: boom"); got != statusErrorDuration {
+		t.Errorf("error duration = %v, want %v", got, statusErrorDuration)
+	}
+}
+
+func TestIsStickyStatus(t *testing.T) {
+	if !isStickyStatus("Connecting...") {
+		t.Error("Connecting... should be sticky")
+	}
+	if !isStickyStatus("Watching key for changes...") {
+		t.Error("Watching key for changes... should be sticky")
+	}
+	if isStickyStatus("Value updated") {
+		t.Error("Value updated should not be sticky")
+	}
+}
+
+func TestIsErrorStatus(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"Error: boom", true},
+		{"Copy failed: x", true},
+		{"Batch TTL error: x", true},
+		{"Invalid TTL: must be an integer (seconds)", true},
+		{"Value updated", false},
+		{"Connected", false},
+	}
+	for _, tc := range cases {
+		if got := isErrorStatus(tc.msg); got != tc.want {
+			t.Errorf("isErrorStatus(%q) = %v, want %v", tc.msg, got, tc.want)
+		}
+	}
+}
+
+func TestUpdate_StatusClearMsg(t *testing.T) {
+	m, _, _ := newTestModel(t)
+	m.StatusMsg = "Value updated"
+	m.statusID = 1
+	result, cmd := m.Update(types.StatusClearMsg{ID: 1})
+	if cmd != nil {
+		t.Fatal("expected nil cmd")
+	}
+	if result.(Model).StatusMsg != "" {
+		t.Errorf("StatusMsg = %q, want empty", result.(Model).StatusMsg)
+	}
+}
+
+func TestUpdate_SchedulesStatusClear(t *testing.T) {
+	t.Run("success toast", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		result, cmd := m.Update(types.ClipboardCopiedMsg{})
+		model := result.(Model)
+		if model.StatusMsg != "Copied to clipboard" {
+			t.Fatalf("StatusMsg = %q, want Copied to clipboard", model.StatusMsg)
+		}
+		if cmd == nil {
+			t.Fatal("expected status clear cmd")
+		}
+		if model.statusID == 0 {
+			t.Error("expected statusID to increment")
+		}
+	})
+	t.Run("sticky connecting does not schedule", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		result, cmd := m.Update(types.AutoConnectMsg{Connection: types.Connection{Name: "local"}})
+		model := result.(Model)
+		if model.StatusMsg != "Connecting..." {
+			t.Fatalf("StatusMsg = %q, want Connecting...", model.StatusMsg)
+		}
+		if cmd == nil {
+			t.Fatal("expected connect cmd")
+		}
+		msg := cmd()
+		if _, ok := msg.(types.StatusClearMsg); ok {
+			t.Fatal("sticky status must not emit StatusClearMsg")
+		}
+	})
+	t.Run("unchanged status does not reschedule", func(t *testing.T) {
+		m, _, _ := newTestModel(t)
+		m.StatusMsg = "Value updated"
+		m.statusID = 9
+		result, cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+		if cmd != nil {
+			t.Fatal("expected nil cmd when status is unchanged")
+		}
+		if result.(Model).statusID != 9 {
+			t.Errorf("statusID = %d, want 9", result.(Model).statusID)
+		}
+	})
+}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -10,6 +10,16 @@ import (
 )
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if clear, ok := msg.(types.StatusClearMsg); ok {
+		return m.handleStatusClear(clear)
+	}
+	prevStatus := m.StatusMsg
+	model, cmd := m.dispatch(msg)
+	updated := model.(Model)
+	return updated, tea.Batch(cmd, updated.scheduleStatusClear(prevStatus))
+}
+
+func (m Model) dispatch(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width


### PR DESCRIPTION
## Context
Inspecting a key briefly showed `Loading...`, then the previous bottom-bar toast (`Connected`, `Value updated`, and similar) came back and stayed until some later action replaced it. Saving or watching a key did the same: the flash never timed out.

## Demo
1. Connect to a Redis instance. Confirm `Connected` disappears from the bottom bar after about 2 seconds.
2. Open a key. Confirm the leftover connect/update toast does not return after `Loading...`.
3. Edit and save a string value. Confirm `Value updated` appears, then clears on its own after about 2 seconds.
4. Trigger an error (for example an invalid TTL). Confirm the error stays a bit longer (about 4 seconds).
5. Start watch mode. Confirm `Watching key for changes...` stays until watch is stopped.

## Changes
- Auto-dismiss transient status toasts after 2s (4s for errors) via `StatusClearMsg` in `internal/ui/status.go`
- Keep in-progress statuses (`Connecting...`, `Watching key for changes...`) until the operation ends
- Clear leftover status when opening a key from the list so inspect no longer resurrects the last toast
- Ignore stale clear timers when a newer status has already replaced the old one

## Notes
Errors still use the status bar; they just expire instead of pinning the footer forever.
